### PR TITLE
r1.0.0-RC2

### DIFF
--- a/refuel-container/src/main/scala/refuel/container/RuntimeInjectionPool.scala
+++ b/refuel-container/src/main/scala/refuel/container/RuntimeInjectionPool.scala
@@ -56,7 +56,7 @@ object RuntimeInjectionPool extends refuel.injector.InjectionPool {
             case x if x.toType.<:<(u.weakTypeTag[AutoInject[T]].tpe) =>
               x.annotations.find(_.tree.tpe.=:=(EFFECTIVE_ANNO_TYPE)).flatMap(_.tree.children.lastOption) -> x
           }
-        )(reflector.reflectClass[T])(c)
+        )(reflector.reflectClass[T](this))(c)
     }
   }
 

--- a/refuel-container/src/main/scala/refuel/container/RuntimeInjectionPool.scala
+++ b/refuel-container/src/main/scala/refuel/container/RuntimeInjectionPool.scala
@@ -10,6 +10,8 @@ import scala.reflect.runtime.{universe => u}
 
 object RuntimeInjectionPool extends refuel.injector.InjectionPool {
 
+  private[this] trait Dummy
+
   /* Effective type symbol */
   private[this] lazy val EFFECTIVE_ANNO_TYPE = u.weakTypeOf[Effective]
   /* Reflector */
@@ -25,7 +27,7 @@ object RuntimeInjectionPool extends refuel.injector.InjectionPool {
     { c: Container =>
       c.findEffect match {
         case x if x.nonEmpty => x
-        case _               => collect[Effect]
+        case _ => collect[Effect](classOf[Effect])
           .apply(c)
           .filter(_.value.activate)
           .map(_.value)
@@ -42,7 +44,7 @@ object RuntimeInjectionPool extends refuel.injector.InjectionPool {
     * @tparam T Type you are trying to get
     * @return
     */
-  def collect[T](implicit wtt: u.WeakTypeTag[T]): InjectionApplyment[T] = { c =>
+  def collect[T](clazz: Class[_])(implicit wtt: u.WeakTypeTag[T]): InjectionApplyment[T] = { c =>
     mayBeEffectiveApply[T, u.ModuleSymbol](
       buffer.modules.collect {
         case x if x.typeSignature.<:<(u.weakTypeTag[AutoInject[T]].tpe) =>
@@ -50,13 +52,13 @@ object RuntimeInjectionPool extends refuel.injector.InjectionPool {
       }
     )(reflector.reflectModule[T])(c) match {
       case x if x.nonEmpty => x
-      case _               =>
+      case _ =>
         mayBeEffectiveApply[T, u.ClassSymbol](
           buffer.classes.collect {
             case x if x.toType.<:<(u.weakTypeTag[AutoInject[T]].tpe) =>
               x.annotations.find(_.tree.tpe.=:=(EFFECTIVE_ANNO_TYPE)).flatMap(_.tree.children.lastOption) -> x
           }
-        )(reflector.reflectClass[T](this))(c)
+        )(reflector.reflectClass[T](clazz, this))(c)
     }
   }
 
@@ -79,7 +81,7 @@ object RuntimeInjectionPool extends refuel.injector.InjectionPool {
     v.partition(_._1.isEmpty) match {
       case (nonEffect, effect) if effect.isEmpty =>
         f(c)(nonEffect.map(_._2))
-      case (nonEffect, effect)                   =>
+      case (nonEffect, effect) =>
         val activeEff = getEffect(c).map(_.getClass.getTypeName)
         f(c) {
           nonEffect.map(_._2) ++ {

--- a/refuel-container/src/main/scala/refuel/container/RuntimeReflector.scala
+++ b/refuel-container/src/main/scala/refuel/container/RuntimeReflector.scala
@@ -2,15 +2,16 @@ package refuel.container
 
 import java.net.{URI, URL}
 
-import refuel.injector.AutoInject
 import refuel.injector.scope.IndexedSymbol
+import refuel.injector.{AutoInject, InjectionPool, Injector}
+import refuel.internal.ClassTypeAcceptContext
 import refuel.runtime.InjectionReflector
 
 import scala.annotation.tailrec
 import scala.reflect.runtime.universe
 
 
-object RuntimeReflector extends InjectionReflector {
+object RuntimeReflector extends InjectionReflector with Injector {
 
   def mirror: universe.Mirror = universe.runtimeMirror(getClass.getClassLoader)
 
@@ -21,11 +22,29 @@ object RuntimeReflector extends InjectionReflector {
     * @tparam T injection type
     * @return
     */
-  override def reflectClass[T: universe.WeakTypeTag](c: Container)(symbols: Set[universe.ClassSymbol]): Set[IndexedSymbol[T]] = {
+  override def reflectClass[T: universe.WeakTypeTag](ip: InjectionPool)(c: Container)(symbols: Set[universe.ClassSymbol]): Set[IndexedSymbol[T]] = {
     symbols.map { x =>
+//      println(x)
+//      println(x.primaryConstructor.asMethod.paramLists.flatten)
+      val pcInject = x.primaryConstructor.asMethod.paramLists.flatten.map { prm =>
+        val tpe: universe.WeakTypeTag[_] = universe.WeakTypeTag(implicitly[universe.WeakTypeTag[T]].mirror, new reflect.api.TypeCreator {
+          def apply[U <: reflect.api.Universe with Singleton](m: reflect.api.Mirror[U]) = {
+            assert(m eq mirror, s"TypeTag[$prm] defined in $mirror cannot be migrated to $m.")
+            println(prm)
+            prm.typeSignature.asInstanceOf[U#Type]
+          }
+        })
+        c.find(this.getClass)(tpe, ClassTypeAcceptContext).getOrElse {
+          ip.collect(tpe).apply(c).toVector
+            .sortBy(_.priority)(Ordering.Int.reverse)
+            .headOption
+            .map(_.value)
+        }
+      }
+//      println
       mirror.reflectClass(x)
         .reflectConstructor(x.primaryConstructor.asMethod)
-        .apply()
+        .apply(pcInject: _*)
         .asInstanceOf[AutoInject[T]] match {
         case ai => ai.flush(c)
       }
@@ -62,9 +81,9 @@ object RuntimeReflector extends InjectionReflector {
   @tailrec
   private[this] def getClassLoaderUrls(cl: ClassLoader): Seq[URL] = {
     cl match {
-      case null                       => Nil
+      case null => Nil
       case x: java.net.URLClassLoader => x.getURLs.toSeq
-      case x                          => getClassLoaderUrls(x.getParent)
+      case x => getClassLoaderUrls(x.getParent)
     }
   }
 
@@ -89,7 +108,7 @@ object RuntimeReflector extends InjectionReflector {
       .withFilter(x => IGNORE_PATHS.forall(!x.contains(_)))
       .map {
         case x if x.endsWith(".jar") => JAR_SCHEME.format(x)
-        case x                       => FILE_SCHEME.format(x)
+        case x => FILE_SCHEME.format(x)
       }.map(new URI(_).toURL).toList
   }
 }

--- a/refuel-container/src/main/scala/refuel/injector/MetaMediation.scala
+++ b/refuel-container/src/main/scala/refuel/injector/MetaMediation.scala
@@ -66,6 +66,19 @@ private[refuel] trait MetaMediation[C <: Container] extends CanBeContainer[C] { 
 
   /**
     * Get accessible dependencies.
+    *
+    * The type information is resolved at compile time, but the injection object is finalized at runtime.
+    * This function is slower than [[refuel.injector.MetaMediation.bind]], but can be overwritten by flush or narrow.
+    *
+    * @param ctn    Container
+    * @param access Accessor (This refers to itself)
+    * @tparam T Injection type
+    * @return
+    */
+  protected def inject[T](t: TypeTag[T])(implicit ctn: C, ip: InjectionPool, access: Accessor[_]): Lazy[T] = macro Macro.lazyInjectDyn[T]
+
+  /**
+    * Get accessible dependencies.
     * You can detect errors that can not be assigned at compile time.
     *
     * It is faster than [[refuel.injector.MetaMediation.inject]] because of immediate assignment,

--- a/refuel-container/src/main/scala/refuel/runtime/InjectionReflector.scala
+++ b/refuel-container/src/main/scala/refuel/runtime/InjectionReflector.scala
@@ -13,7 +13,7 @@ trait InjectionReflector {
     * @tparam T injection type
     * @return
     */
-  def reflectClass[T: universe.WeakTypeTag](ip: InjectionPool)(c: Container)(x: Set[universe.ClassSymbol]): Set[IndexedSymbol[T]]
+  def reflectClass[T: universe.WeakTypeTag](clazz: Class[_], ip: InjectionPool)(c: Container)(x: Set[universe.ClassSymbol]): Set[IndexedSymbol[T]]
 
   /**
     * Create injection applyment.

--- a/refuel-container/src/main/scala/refuel/runtime/InjectionReflector.scala
+++ b/refuel-container/src/main/scala/refuel/runtime/InjectionReflector.scala
@@ -1,6 +1,7 @@
 package refuel.runtime
 
 import refuel.container.Container
+import refuel.injector.InjectionPool
 import refuel.injector.scope.IndexedSymbol
 
 import scala.reflect.runtime.universe
@@ -12,7 +13,7 @@ trait InjectionReflector {
     * @tparam T injection type
     * @return
     */
-  def reflectClass[T: universe.WeakTypeTag](c: Container)(x: Set[universe.ClassSymbol]): Set[IndexedSymbol[T]]
+  def reflectClass[T: universe.WeakTypeTag](ip: InjectionPool)(c: Container)(x: Set[universe.ClassSymbol]): Set[IndexedSymbol[T]]
 
   /**
     * Create injection applyment.

--- a/refuel-container/src/main/scala/refuel/runtime/RuntimeAutoDIExtractor.scala
+++ b/refuel-container/src/main/scala/refuel/runtime/RuntimeAutoDIExtractor.scala
@@ -40,7 +40,8 @@ object RuntimeAutoDIExtractor {
       entries.classSymbolPath.flatMap { x =>
         try {
           RuntimeReflector.mirror.staticClass(x) match {
-            case r if r.toType <:< autoDITag => Some(r)
+            case r if r.toType <:< autoDITag =>
+              Some(r)
             case _                           => None
           }
         } catch {

--- a/refuel-container/src/main/scala/refuel/runtime/RuntimeAutoInjectableSymbols.scala
+++ b/refuel-container/src/main/scala/refuel/runtime/RuntimeAutoInjectableSymbols.scala
@@ -2,18 +2,4 @@ package refuel.runtime
 
 import scala.reflect.runtime.universe._
 
-private[refuel] object RuntimeAutoInjectableSymbols {
-  def empty: RuntimeAutoInjectableSymbols = {
-    RuntimeAutoInjectableSymbols(Set.empty, Set.empty)
-  }
-}
-
-private[refuel] case class RuntimeAutoInjectableSymbols(modules: Set[ModuleSymbol], classes: Set[ClassSymbol]) {
-  def add(ms: Set[ModuleSymbol], cs: Set[ClassSymbol]): RuntimeAutoInjectableSymbols = {
-    RuntimeAutoInjectableSymbols(modules ++ ms, classes ++ cs)
-  }
-
-  def ++(that: RuntimeAutoInjectableSymbols): RuntimeAutoInjectableSymbols = {
-    copy(modules ++ that.modules, classes ++ that.classes)
-  }
-}
+private[refuel] case class RuntimeAutoInjectableSymbols(modules: Set[ModuleSymbol], classes: Set[ClassSymbol])

--- a/refuel-container/src/test/scala/refuel/ClassSymbolInjectionTest.scala
+++ b/refuel-container/src/test/scala/refuel/ClassSymbolInjectionTest.scala
@@ -146,7 +146,7 @@ object ClassSymbolInjectionTest {
       val first: G_FIRST_PARAM
     }
 
-    class G_IMPL(val first: G_FIRST_PARAM)(val inner: G_INNER[G_TYPE_PARAM_A]) extends G with AutoInject[G]
+    class G_IMPL(val first: G_FIRST_PARAM, val inner: G_INNER[G_TYPE_PARAM_A]) extends G with AutoInject[G]
 
   }
 
@@ -240,11 +240,12 @@ class ClassSymbolInjectionTest extends AsyncWordSpec with Matchers with Diagramm
       import refuel.ClassSymbolInjectionTest.TEST_G._
 
       try {
-        inject[G]._provide
-        fail()
+        val result = inject[G]._provide
+        result.inner.t shouldBe G_TYPE_PARAM_A()
+        result.first shouldBe G_FIRST_PARAM_IMPL
       } catch {
         case _: DIAutoInitializationException => succeed
-        case _: Throwable => fail()
+        case e: Throwable => fail(e.getMessage)
       }
     }
   }

--- a/refuel-container/src/test/scala/refuel/ClassSymbolInjectionTest.scala
+++ b/refuel-container/src/test/scala/refuel/ClassSymbolInjectionTest.scala
@@ -6,6 +6,7 @@ import refuel.exception.DIAutoInitializationException
 import refuel.injector.{AutoInject, InjectOnce, Injector}
 import refuel.provider.Tag
 import org.scalatest.{AsyncWordSpec, DiagrammedAssertions, Matchers}
+import refuel.ClassSymbolInjectionTest.TEST_G.{G, G_TYPE_PARAM_A}
 
 
 object ClassSymbolInjectionTest {
@@ -177,6 +178,11 @@ object ClassSymbolInjectionTest {
     case class JAliasImpl() extends J_ALIAS with AutoInject[J_ALIAS]
   }
 
+  object TEST_K {
+    trait K
+    case class KImpl(vvv: String) extends K with AutoInject[K]
+  }
+
 }
 
 class ClassSymbolInjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertions with Injector {
@@ -236,15 +242,24 @@ class ClassSymbolInjectionTest extends AsyncWordSpec with Matchers with Diagramm
       a should not be b
     }
 
-    "If primary constructor has parameters, inject[T] is fail" in {
+    "If primary constructor has parameters, inject[T] is recursive inject" in {
       import refuel.ClassSymbolInjectionTest.TEST_G._
 
-      try {
         val result = inject[G]._provide
         result.inner.t shouldBe G_TYPE_PARAM_A()
         result.first shouldBe G_FIRST_PARAM_IMPL
+    }
+
+    "If primary constructor has parameters, and not found target, inject[T] is fail" in {
+      import refuel.ClassSymbolInjectionTest.TEST_K._
+
+      try {
+        inject[K]._provide
+        fail()
       } catch {
-        case _: DIAutoInitializationException => succeed
+        case e: DIAutoInitializationException =>
+          e.printStackTrace()
+          succeed
         case e: Throwable => fail(e.getMessage)
       }
     }

--- a/refuel-container/src/test/scala/refuel/ClassSymbolInjectionTest.scala
+++ b/refuel-container/src/test/scala/refuel/ClassSymbolInjectionTest.scala
@@ -1,12 +1,12 @@
 package refuel
 
+import org.scalatest.{AsyncWordSpec, DiagrammedAssertions, Matchers}
+import refuel.ClassSymbolInjectionTest.TEST_K.K
 import refuel.Types.@@
 import refuel.effect.{Effect, Effective}
 import refuel.exception.DIAutoInitializationException
 import refuel.injector.{AutoInject, InjectOnce, Injector}
 import refuel.provider.Tag
-import org.scalatest.{AsyncWordSpec, DiagrammedAssertions, Matchers}
-import refuel.ClassSymbolInjectionTest.TEST_G.{G, G_TYPE_PARAM_A}
 
 
 object ClassSymbolInjectionTest {
@@ -176,11 +176,26 @@ object ClassSymbolInjectionTest {
     type J_ALIAS = J
 
     case class JAliasImpl() extends J_ALIAS with AutoInject[J_ALIAS]
+
   }
 
   object TEST_K {
+
     trait K
+
     case class KImpl(vvv: String) extends K with AutoInject[K]
+
+  }
+
+  object TEST_L {
+
+    trait L {
+      val value: LInner
+    }
+    trait LInner
+
+    case class LImpl(value: LInner) extends L with AutoInject[L]
+
   }
 
 }
@@ -245,9 +260,9 @@ class ClassSymbolInjectionTest extends AsyncWordSpec with Matchers with Diagramm
     "If primary constructor has parameters, inject[T] is recursive inject" in {
       import refuel.ClassSymbolInjectionTest.TEST_G._
 
-        val result = inject[G]._provide
-        result.inner.t shouldBe G_TYPE_PARAM_A()
-        result.first shouldBe G_FIRST_PARAM_IMPL
+      val result = inject[G]._provide
+      result.inner.t shouldBe G_TYPE_PARAM_A()
+      result.first shouldBe G_FIRST_PARAM_IMPL
     }
 
     "If primary constructor has parameters, and not found target, inject[T] is fail" in {
@@ -258,10 +273,22 @@ class ClassSymbolInjectionTest extends AsyncWordSpec with Matchers with Diagramm
         fail()
       } catch {
         case e: DIAutoInitializationException =>
-          e.printStackTrace()
           succeed
         case e: Throwable => fail(e.getMessage)
       }
+    }
+
+    "If primary constructor has parameters, and bounds are specified, switched inject result." in {
+      import refuel.ClassSymbolInjectionTest.TEST_L._
+
+      val inner1 = new LInner {
+      }
+      val inner2 = new LInner {
+      }
+      val inner3 = new LInner {
+      }
+      narrow[LInner](inner2).accept[L].indexing()
+      inject[L]._provide.value shouldBe inner2
     }
   }
 
@@ -279,11 +306,11 @@ class ClassSymbolInjectionTest extends AsyncWordSpec with Matchers with Diagramm
     }
   }
 
-//  "type alias injection" should {
-//    "Can inject each alias" in {
-//      import refuel.ClassSymbolInjectionTest.TEST_J._
-//      inject[J]._provide shouldBe JImpl()
-//      inject[J_ALIAS]._provide shouldBe JAliasImpl()
-//    }
-//  }
+  //  "type alias injection" should {
+  //    "Can inject each alias" in {
+  //      import refuel.ClassSymbolInjectionTest.TEST_J._
+  //      inject[J]._provide shouldBe JImpl()
+  //      inject[J_ALIAS]._provide shouldBe JAliasImpl()
+  //    }
+  //  }
 }

--- a/refuel-json/src/test/scala/refuel/json/codecs/factory/ConstCodecTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/factory/ConstCodecTest.scala
@@ -1,6 +1,6 @@
 package refuel.json.codecs.factory
 
-import refuel.json.JsParser
+import refuel.json.{Codec, JsParser}
 import refuel.json.codecs.factory.ConstCodecTest._
 import org.scalatest.{AsyncWordSpec, DiagrammedAssertions, Matchers}
 
@@ -32,36 +32,9 @@ class ConstCodecTest extends AsyncWordSpec with Matchers with DiagrammedAssertio
       }
     }
   }
-
-
-  "Customized case" should {
-    "sss" in {
-      s"""{"hoge": {"min": 0, "max": 1}}""".as(
-        ConstCodec.from[From, To]("hoge"){
-          case From(Some(a), Some(b)) => To(a, b)
-        }{
-          case To(a, b) => Some(From(Some(a), Some(b)))
-        }
-      ) shouldBe Right(To(0, 1))
-    }
-    "to" in {
-      To(0, 1).toJson(
-        ConstCodec.from[From, To]("hoge"){
-          case From(Some(a), Some(b)) => To(a, b)
-        }{
-          case To(a, b) => Some(From(Some(a), Some(b)))
-        }
-      ).toString shouldBe s"""{"hoge":{"min":0,"max":1}}"""
-    }
-  }
-
 }
 
 object ConstCodecTest {
-
-  case class To(min: Int, max: Int)
-
-  case class From(min: Option[Int], max: Option[Int])
 
   case class WrappedType(wrap: InnerType)
 
@@ -94,4 +67,17 @@ object ConstCodecTest {
                      u: Int,
                      v: Int)
 
+  case class From(value: Option[Int])
+
+  case class To[T](value: T)
+
+  object CodecBuildTest extends JsParser {
+
+    def apply(): Codec[To[Int]] =
+      ConstCodec.from[From, To[Int]]("test") { x =>
+        To(x.value.get)
+      } { x =>
+        Some(From(Some(x.value)))
+      }
+  }
 }

--- a/refuel-json/src/test/scala/refuel/json/codecs/factory/ConstCodecTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/factory/ConstCodecTest.scala
@@ -32,9 +32,36 @@ class ConstCodecTest extends AsyncWordSpec with Matchers with DiagrammedAssertio
       }
     }
   }
+
+
+  "Customized case" should {
+    "sss" in {
+      s"""{"hoge": {"min": 0, "max": 1}}""".as(
+        ConstCodec.from[From, To]("hoge"){
+          case From(Some(a), Some(b)) => To(a, b)
+        }{
+          case To(a, b) => Some(From(Some(a), Some(b)))
+        }
+      ) shouldBe Right(To(0, 1))
+    }
+    "to" in {
+      To(0, 1).toJson(
+        ConstCodec.from[From, To]("hoge"){
+          case From(Some(a), Some(b)) => To(a, b)
+        }{
+          case To(a, b) => Some(From(Some(a), Some(b)))
+        }
+      ).toString shouldBe s"""{"hoge":{"min":0,"max":1}}"""
+    }
+  }
+
 }
 
 object ConstCodecTest {
+
+  case class To(min: Int, max: Int)
+
+  case class From(min: Option[Int], max: Option[Int])
 
   case class WrappedType(wrap: InnerType)
 

--- a/refuel-json/src/test/scala/refuel/json/codecs/factory/TestTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/factory/TestTest.scala
@@ -1,0 +1,24 @@
+package refuel.json.codecs.factory
+
+import refuel.json.{Codec, JsParser}
+
+case class From(value: Option[Int])
+
+case class To[T](value: T)
+
+object PixelSizeCodec extends JsParser {
+
+  def apply(): Codec[To[Int]] =
+    ConstCodec.from[From, To[Int]]("test") { x =>
+      To(x.value.get)
+    } { x =>
+      Some(From(Some(x.value)))
+    }
+
+  // case class PixelSizeDefine(min: Option[Int], max: Option[Int])
+}
+
+
+class TestTest {
+
+}

--- a/refuel-macro/src/main/scala/refuel/injector/InjectionPool.scala
+++ b/refuel-macro/src/main/scala/refuel/injector/InjectionPool.scala
@@ -19,5 +19,5 @@ trait InjectionPool {
     * @tparam T Type you are trying to get
     * @return
     */
-  def collect[T](implicit wtt: WeakTypeTag[T]): InjectionApplyment[T]
+  def collect[T](clazz: Class[_])(implicit wtt: WeakTypeTag[T]): InjectionApplyment[T]
 }

--- a/refuel-macro/src/main/scala/refuel/internal/InjectionCompound.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/InjectionCompound.scala
@@ -1,7 +1,6 @@
 package refuel.internal
 
-import refuel.container.{Container, CanBeContainer}
-import refuel.exception.InjectDefinitionException
+import refuel.container.{CanBeContainer, Container}
 import refuel.injector.AutoInjectable
 
 import scala.reflect.macros.blackbox
@@ -13,13 +12,13 @@ class InjectionCompound[C <: blackbox.Context](val c: C) {
   def buildOne[T: c.WeakTypeTag](ctn: c.Tree)(msList: Iterable[c.Symbol], mayBeCs: Option[c.Symbol]): c.Expr[T] = {
 
     (msList, mayBeCs) match {
-      case (x, None) if x.isEmpty =>
+      case (x, None) if x.isEmpty     =>
         c.error(c.enclosingPosition, s"Cannot found automatic injection target of ${weakTypeOf[T].typeSymbol.fullName}.")
-        throw new InjectDefinitionException(s"Automatic injection target can not be found.")
+        c.abort(c.enclosingPosition, s"Automatic injection target can not be found.")
       case (x, Some(cs)) if x.isEmpty =>
         c.echo(c.enclosingPosition, s"Actual candidates ${cs.name}.")
         createNewInstance(ctn)(cs)
-      case (x, _) =>
+      case (x, _)                     =>
         c.echo(c.enclosingPosition, s"Actual candidates [${x.map(_.name).mkString(", ")}]")
         val flushed = x.map { name =>
           c.Expr[AutoInjectable[T]](

--- a/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
@@ -79,12 +79,6 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
     }
   }
 
-  def classpathRepooling[T: C#WeakTypeTag](fun: Tree, ctn: c.Tree, ip: Tree): Expr[T] = {
-    reify {
-      c.Expr[T](fun).splice
-    }
-  }
-
   def diligentInit[T: c.WeakTypeTag](ctn: Tree, ip: Tree, access: c.Tree): Expr[T] = {
     AutoDIExtractor.collectApplyTarget[c.type, T](c)(ctn)
   }

--- a/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
@@ -42,7 +42,7 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
           })
         } catch {
           case e: Throwable =>
-            throw new DIAutoInitializationException(s"${typName.splice} or its internal initialize failed.", e)
+            throw new DIAutoInitializationException(s"Failed to initialize ${typName.splice}.", e)
         }
       }
     }

--- a/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
@@ -75,7 +75,10 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
 
   private def applymentFunction[T: WeakTypeTag](cnt: Tree, ip: Tree): c.Expr[Set[IndexedSymbol[T]]] = {
     reify {
-      c.Expr[InjectionPool](ip).splice.collect[T].apply(c.Expr[Container](cnt).splice)
+      c.Expr[InjectionPool](ip)
+        .splice
+        .collect[T](c.Expr[Class[T]](c.reifyRuntimeClass(weakTypeOf[T])).splice)
+        .apply(c.Expr[Container](cnt).splice)
     }
   }
 

--- a/refuel-macro/src/main/scala/refuel/internal/Macro.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/Macro.scala
@@ -5,13 +5,11 @@ import refuel.provider.Lazy
 import scala.reflect.macros.blackbox
 
 
-object Macro {
+class Macro(val c: blackbox.Context) {
 
-  def reifyClasspathInjectables[T: c.WeakTypeTag](c: blackbox.Context)(fun: c.Tree)(ctn: c.Tree, ip: c.Tree): c.Expr[T] = {
-    new LazyInitializer[c.type](c).classpathRepooling[T](fun, ctn, ip)
-  }
+  // def reinjectPrimaryConstruction[T: c.WeakTypeTag](apl: c.Expr[T]):
 
-  def lazyInject[T: c.WeakTypeTag](c: blackbox.Context)(ctn: c.Tree, ip: c.Tree, access: c.Tree): c.Expr[Lazy[T]] = {
+  def lazyInjectDyn[T: c.WeakTypeTag](t: c.Tree)(ctn: c.Tree, ip: c.Tree, access: c.Tree): c.Expr[Lazy[T]] = {
     new LazyInitializer[c.type](c).lazyInit[T](
       ctn,
       ip,
@@ -19,7 +17,15 @@ object Macro {
     )
   }
 
-  def diligentInject[T: c.WeakTypeTag](c: blackbox.Context)(ctn: c.Tree, ip: c.Tree, access: c.Tree): c.Expr[T] = {
+  def lazyInject[T: c.WeakTypeTag](ctn: c.Tree, ip: c.Tree, access: c.Tree): c.Expr[Lazy[T]] = {
+    new LazyInitializer[c.type](c).lazyInit[T](
+      ctn,
+      ip,
+      access
+    )
+  }
+
+  def diligentInject[T: c.WeakTypeTag](ctn: c.Tree, ip: c.Tree, access: c.Tree): c.Expr[T] = {
     new LazyInitializer[c.type](c).diligentInit[T](
       ctn,
       ip,
@@ -27,7 +33,7 @@ object Macro {
     )
   }
 
-  def scratch(c: blackbox.Context): c.Tree = {
+  def scratch: c.Tree = {
     import c.universe._
     q"""
       throw new refuel.exception.UnExceptedOperateException("If you have already authorized any instance, you can not authorize new types.")

--- a/refuel-macro/src/main/scala/refuel/internal/json/ConstructCodecFactory.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/json/ConstructCodecFactory.scala
@@ -32,7 +32,7 @@ class ConstructCodecFactory(override val c: blackbox.Context) extends CaseCodecF
              $jsonEntryPkg.JsObject()
                .++($jsonEntryPkg.JsString($n1))
                .++(_)
-           """).splice.apply(recall(weakTypeOf[A]).splice.serialize(upl.splice.apply(t)))
+           """).splice.apply(recall(weakTypeOf[A]).splice.serialize(upl.splice.apply(t).get))
         }
       }
     }

--- a/refuel-macro/src/main/scala/refuel/internal/json/Wrapped.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/json/Wrapped.scala
@@ -1,5 +1,0 @@
-package refuel.internal.json
-
-class Wrapped[T](val value: T) {
-
-}

--- a/refuel-macro/src/main/scala/refuel/internal/package.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/package.scala
@@ -20,7 +20,7 @@ package object internal {
 
   implicit case object ClassTypeAcceptContext extends TypedAcceptContext[Class[_]] {
     override def accepted: IndexedSymbol[_] => Class[_] => Boolean = { x => y =>
-      x.isOpen || x.acceptedClass(y.getClass)
+      x.isOpen || x.acceptedClass(y)
     }
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.0.0-RC1"
+version in ThisBuild := "1.0.0-RC2"


### PR DESCRIPTION
## Add a function that constructor injection at runtime.

Previously supported only by macro injection, constructor injection is also supported by runtime.

```scala
class AAA(a: A, b: B) extends AAA with AutoInject[AAA]
inject[AAA] // it will be new AAA(inject[A], inject[B])
```

If there are no applicable parameters, an error will occur.

```
refuel.exception.DIAutoInitializationException: Failed to initialize interface AAA.
Caused by: refuel.exception.DIAutoInitializationException: Injectable parameter String of AAA constructor not found
```

## Access rules are also applied to constructor injection.

Setting class type acceptable works in constructor injection.

```scala
overwrite[A](new A1()).accept[BBB].indexing()
overwrite[A](new A2()).accept[AAA].indexing()
class AAA(a: A) extends AAA with AutoInject[AAA]
inject[AAA] // it will be new AAA(new A2())
```

The object "AAA" generated by the constructor may not have been generated at the time of injection, so object type acceptable may not be applicable.

## Fixed a bug that single tuple constructor codec could not be compiled.

```scala
ConstCodec.from("x")(...)(...) // Compilation failed
```
