### PR TITLE
Fix http client syntax.

### DIFF
--- a/refuel-container/README.md
+++ b/refuel-container/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-container" % "1.1.2"
+libraryDependencies += "com.phylage" %% "refuel-container" % "1.1.3"
 ````
 
 ## Features

--- a/refuel-http/README.md
+++ b/refuel-http/README.md
@@ -4,7 +4,7 @@
 
 ```
 libraryDependencies ++= Seq(
-  "com.phylage"       %% "refuel-http" % "1.1.2,
+  "com.phylage"       %% "refuel-http" % "1.1.3,
   "com.typesafe.akka" %% "akka-stream" % "2.6.4",
   "com.typesafe.akka" %% "akka-http"   % "10.1.11"
 )

--- a/refuel-http/src/main/scala/refuel/http/io/HttpResultTask.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpResultTask.scala
@@ -1,9 +1,10 @@
 package refuel.http.io
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.HttpRequest
 
 import scala.concurrent.Future
 
 trait HttpResultTask[T] {
-  def execute(request: HttpRequest): Future[T]
+  def execute(request: HttpRequest)(implicit as: ActorSystem): Future[T]
 }

--- a/refuel-http/src/main/scala/refuel/http/io/setting/HttpSetting.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/setting/HttpSetting.scala
@@ -1,6 +1,5 @@
 package refuel.http.io.setting
 
-import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpEntity, HttpProtocols, HttpRequest}
 import refuel.domination.Inject
 import refuel.domination.InjectionPriority.Finally
@@ -29,8 +28,7 @@ import refuel.injector.AutoInject
 class HttpSetting(
     val retryThreshold: Int = 1,
     val requestBuilder: HttpRequest => HttpRequest = HttpSetting.DEFAULT,
-    val responseBuilder: HttpEntity.Strict => HttpEntity.Strict = x => x,
-    val actorSystem: ActorSystem
+    val responseBuilder: HttpEntity.Strict => HttpEntity.Strict = x => x
 )
 
 object HttpSetting {
@@ -42,8 +40,6 @@ object HttpSetting {
   }
 
   @Inject(Finally)
-  class RecoveredHttpSetting(override val actorSystem: ActorSystem)
-      extends HttpSetting(actorSystem = actorSystem)
-      with AutoInject
+  class RecoveredHttpSetting() extends HttpSetting() with AutoInject
 
 }

--- a/refuel-http/src/test/scala/refuel/http/io/HttpTest.scala
+++ b/refuel-http/src/test/scala/refuel/http/io/HttpTest.scala
@@ -26,7 +26,7 @@ object HttpTest extends Injector {
 
 class HttpTest extends AsyncWordSpec with Matchers with DiagrammedAssertions with Injector with CodecDef {
 
-  ActorSystem().index()
+  implicit val as: ActorSystem = ActorSystem().index()
 
   "Http io test" should {
 

--- a/refuel-json/README.md
+++ b/refuel-json/README.md
@@ -1,7 +1,7 @@
 # refuel-json
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-json" % "1.1.2"
+libraryDependencies += "com.phylage" %% "refuel-json" % "1.1.3"
 ```
 
 refuel-json automatically generates codec and supports JSON mutual conversion fast and easy.

--- a/refuel-json/src/main/scala/refuel/json/tokenize/combinator/ExtensibleIndexWhere.scala
+++ b/refuel-json/src/main/scala/refuel/json/tokenize/combinator/ExtensibleIndexWhere.scala
@@ -6,8 +6,7 @@ abstract class ExtensibleIndexWhere(rs: Array[Char]) {
 
   protected var pos: Int
 
-  protected final val length   = rs.length
-  protected final val maxIndex = length - 1
+  protected final val length = rs.length
 
   protected def beEOF: Unit
 

--- a/refuel-util/README.md
+++ b/refuel-util/README.md
@@ -1,7 +1,7 @@
 ## refuel-util
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-util" % "1.1.2"
+libraryDependencies += "com.phylage" %% "refuel-util" % "1.1.3"
 ```
 
 ## Usage

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.1.2"
+version in ThisBuild := "1.1.3"


### PR DESCRIPTION
## Changes

### Removed ActorSystem from HttpSetting.

In many cases, it may be a hassle to register it in the DI container because it should be taken as an implicit parameter in many cases.
Instead, HttpRunner becomes ReaderMonad, which implicitly requires you to pass ActorSystem to run.