### PR TITLE
Feature/support akka request setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,6 @@
 import sbt.Keys.crossScalaVersions
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
-scalaVersion in ThisBuild := "2.13.2"
-
 releaseCrossBuild in Scope.Global := true
 crossScalaVersions in Scope.Global := Seq("2.12.11", "2.13.2")
 

--- a/build.sbt
+++ b/build.sbt
@@ -117,7 +117,9 @@ lazy val container = (project in file("refuel-container"))
 lazy val util = (project in file("refuel-util"))
   .settings(assemblySettings, commonDependencySettings)
   .dependsOn(container)
-  .settings(name := "refuel-util", parallelExecution in Test := true)
+  .settings(
+    name := "refuel-util"
+  )
   .enablePlugins(JavaAppPackaging)
 
 lazy val json = (project in file("refuel-json"))

--- a/refuel-http/src/main/scala/refuel/http/io/Http.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/Http.scala
@@ -3,6 +3,8 @@ package refuel.http.io
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
 import akka.util.ByteString
+import refuel.domination.Inject
+import refuel.domination.InjectionPriority.Finally
 import refuel.http.io.setting.HttpSetting
 import refuel.http.io.setting.HttpSetting.RecoveredHttpSetting
 import refuel.http.io.task.HttpTask
@@ -27,6 +29,7 @@ object Http extends Http(new RecoveredHttpSetting)
   * }
   * }}}
   */
+@Inject(Finally)
 class Http(val setting: HttpSetting) extends Injector with JsonTransform with AutoInject {
 
   implicit def toUri(uri: String): Uri = Uri(uri)

--- a/refuel-http/src/main/scala/refuel/http/io/Http.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/Http.scala
@@ -18,6 +18,7 @@ import scala.concurrent.duration._
 import scala.language.implicitConversions
 
 @deprecated("Instead, use dependency injection")
+@Inject(Finally)
 object Http extends Http(new RecoveredHttpSetting)
 
 /** {{{

--- a/refuel-http/src/main/scala/refuel/http/io/HttpRunner.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpRunner.scala
@@ -33,6 +33,20 @@ sealed class HttpRunner[T](request: HttpRequest, task: HttpResultExecution[T]) e
   }
 
   /**
+    * Set a request body.
+    * You can set up a standard request that is supported by Akka HTTP.
+    *
+    * @param f Request setting function.
+    * @return
+    */
+  def mapRequest(f: HttpRequest => HttpRequest): HttpRunner[T] = {
+    new HttpRunner[T](
+      f(request),
+      task
+    )
+  }
+
+  /**
     * Set request parameters.
     *
     * @param ps parameters.

--- a/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
@@ -27,12 +27,6 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
        """
     )
 
-    val typName = c.Expr {
-      c.reifyRuntimeClass(weakTypeOf[T])
-    }
-
-    val ctnExpr = c.Expr[Container](ctn)
-
     reify[Lazy[T]] {
       new Lazy[T] {
         def _provide: T = injectionRf.splice

--- a/refuel-macro/src/main/scala/refuel/internal/di/SymbolExprGenerator.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/di/SymbolExprGenerator.scala
@@ -32,7 +32,7 @@ class SymbolExprGenerator[C <: blackbox.Context](c: C) {
             clss <- mayBeClss
             if clss.companion.typeSignature.=:=(comp.typeSignature)
           } yield {
-            c.echo(c.enclosingPosition, s"${clss.fullName} will be used.")
+            c.echo(c.enclosingPosition, s"${clss.fullName}(class symbol) will be used.")
             pureGenerateExpr[T](clss)
           }
         }.getOrElse(

--- a/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
+++ b/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
@@ -3,6 +3,8 @@ package refuel.lang
 import java.time.format.DateTimeFormatter
 import java.time.{Instant, LocalDateTime, LocalTime, ZonedDateTime}
 
+import refuel.domination.Inject
+import refuel.domination.InjectionPriority.Finally
 import refuel.injector.{AutoInject, Injector}
 
 @deprecated("Instead, use dependency injection")
@@ -19,6 +21,7 @@ object ScalaTime extends ScalaTime(RuntimeTZ)
   * By default, the system default TimeZone is used.
   * I would override it as needed and refer to it by mixing in the AutoInject.
   */
+@Inject(Finally)
 class ScalaTime(TZ: RuntimeTZ) extends Injector with AutoInject {
 
   /**

--- a/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
+++ b/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
@@ -8,6 +8,7 @@ import refuel.domination.InjectionPriority.Finally
 import refuel.injector.{AutoInject, Injector}
 
 @deprecated("Instead, use dependency injection")
+@Inject(Finally)
 object ScalaTime extends ScalaTime(RuntimeTZ)
 
 /** Use DI as a starting point.
@@ -23,6 +24,8 @@ object ScalaTime extends ScalaTime(RuntimeTZ)
   */
 @Inject(Finally)
 class ScalaTime(TZ: RuntimeTZ) extends Injector with AutoInject {
+
+  println(TZ.ZONE_ID)
 
   /**
     * Get a current time.

--- a/refuel-util/src/test/scala/refuel/lang/ScalaTimeTest.scala
+++ b/refuel-util/src/test/scala/refuel/lang/ScalaTimeTest.scala
@@ -2,16 +2,16 @@ package refuel.lang
 
 import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
-import refuel.injector.Injector
-import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+import refuel.injector.Injector
 
 import scala.util.{Failure, Try}
 
 class ScalaTimeTest extends AnyWordSpec with Matchers with Injector {
 
+  val tz: RuntimeTZ = inject[RuntimeTZ]
   val st: ScalaTime = inject[ScalaTime]
-  val tz            = inject[RuntimeTZ]
 
   import st._
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.0"
+version in ThisBuild := "1.2.1"


### PR DESCRIPTION
## Akka http standard request format is supported.

Some of the constructors provided in Akka were not available, but they are all available from now on.

```scala
http[GET]("http://???")
  .requestMap(_.setEntity(FormData().toEntity))
  .run
``` 

## Be careful about the injection priority when you have a companion object.

```scala
@Inject(Finally)
class A(injectableFoo: Foo) extends AutoInject
object A extends A(new Foo)

class FooImpl extends Foo with AutoInject {
}
inject[A]
// expect: A(new FooImpl)
// actual: A
```
The reason why FooImpl is not used is because class A and object A have different priorities, so object A is selected by ranking.
In this case, the companion object is also AutoInjectable, so we need to set the same level of priority.
```scala
@Inject(Finally)
class A(injectableFoo: Foo) extends AutoInject
@Inject(Finally)
object A extends A(new Foo)
```