### PR TITLE
Can set timeout at response strict.

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.1"
+version in ThisBuild := "1.2.2"


### PR DESCRIPTION
## Timeout in toStrict can now be received and changed with an implicit parameter.

```scala
implicit val StrictTimeout: FiniteDuration = 5.seconds
http[GET]("http://???")
  .as[ResponseType]
  .run
```

If the response takes more than 5 seconds to process, a Timeout will be triggered.
The default is 30 seconds.