### PR TITLE
Change signature

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.10
+sbt.version=1.3.12

--- a/refuel-http/src/main/scala/refuel/http/io/HttpFailed.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpFailed.scala
@@ -1,0 +1,13 @@
+package refuel.http.io
+
+import akka.http.scaladsl.model.{HttpResponse, StatusCode}
+
+sealed class HttpFailed[T](val entry: T) extends Throwable
+
+case class HttpRequestFailed(status: StatusCode, override val entry: HttpResponse)
+    extends HttpFailed[HttpResponse](entry) {
+  override def getMessage: String = s"Http request failed. status code: ${status.value}"
+}
+case class HttpProcessingFailed(override val entry: Throwable) extends HttpFailed[Throwable](entry) {
+  override def getMessage: String = entry.getMessage
+}

--- a/refuel-http/src/main/scala/refuel/http/io/HttpRequestFailed.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpRequestFailed.scala
@@ -1,3 +1,0 @@
-package refuel.http.io
-
-class HttpRequestFailed[T](val body: T) extends Throwable {}

--- a/refuel-http/src/main/scala/refuel/http/io/HttpRequestFailed.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpRequestFailed.scala
@@ -1,0 +1,3 @@
+package refuel.http.io
+
+class HttpRequestFailed[T](val body: T) extends Throwable {}

--- a/refuel-http/src/main/scala/refuel/http/io/HttpRetryRevolver.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpRetryRevolver.scala
@@ -1,10 +1,10 @@
 package refuel.http.io
 
-import refuel.injector.Injector
 import com.typesafe.scalalogging.Logger
+import refuel.injector.Injector
 
-import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.Future
 
 case class HttpRetryRevolver(maxRetry: Int) extends Injector {
 
@@ -22,7 +22,7 @@ case class HttpRetryRevolver(maxRetry: Int) extends Injector {
     func.recoverWith {
       case x if retry >= maxRetry =>
         logger.error(s"Request retry failed.", x)
-        throw x
+        Future.failed(HttpProcessingFailed(x))
       case x =>
         logger.warn(s"Request retry failed. ${x.getMessage}")
         revolving(retry + 1)(func)

--- a/refuel-http/src/main/scala/refuel/http/io/package.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/package.scala
@@ -1,7 +1,7 @@
 package refuel.http
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.HttpMethods
+import akka.http.scaladsl.model.{HttpMethods, StatusCode}
 import refuel.http.io.HttpMethod._
 import refuel.http.io.task.{CombineTask, HttpTask}
 

--- a/refuel-http/src/main/scala/refuel/http/io/task/CombineTask.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/task/CombineTask.scala
@@ -25,4 +25,15 @@ abstract class CombineTask[T] extends HttpTask[T] { me =>
   override def flatMap[R](func: T => HttpTask[R]): HttpTask[R] = new CombineTask[R] {
     override def run(implicit as: ActorSystem): Future[R] = me.run.flatMap(func(_).run)(as.dispatcher)
   }
+
+  override def recover[R >: T](f: PartialFunction[Throwable, R]): HttpTask[R] = new CombineTask[R] {
+    override def run(implicit as: ActorSystem): Future[R] =
+      me.run.recoverWith[R](f.andThen(x => Future.apply(x)(as.dispatcher)))(as.dispatcher)
+  }
+  override def recoverWith[R >: T](f: PartialFunction[Throwable, HttpTask[R]]): HttpTask[R] = new CombineTask[R] {
+    override def run(implicit as: ActorSystem): Future[R] = me.run.recoverWith[R](f.andThen(_.run))(as.dispatcher)
+  }
+  override def recoverF[R >: T](f: PartialFunction[Throwable, Future[R]]): HttpTask[R] = new CombineTask[R] {
+    override def run(implicit as: ActorSystem): Future[R] = me.run.recoverWith[R](f)(as.dispatcher)
+  }
 }

--- a/refuel-http/src/main/scala/refuel/http/io/task/HttpTask.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/task/HttpTask.scala
@@ -1,7 +1,6 @@
 package refuel.http.io.task
 
 import akka.actor.ActorSystem
-import refuel.http.io.HttpRunner
 
 import scala.concurrent.Future
 
@@ -31,4 +30,8 @@ trait HttpTask[T] { me =>
     * @return
     */
   def run(implicit as: ActorSystem): Future[T]
+
+  def recover[R >: T](f: PartialFunction[Throwable, R]): HttpTask[R]
+  def recoverWith[R >: T](f: PartialFunction[Throwable, HttpTask[R]]): HttpTask[R]
+  def recoverF[R >: T](f: PartialFunction[Throwable, Future[R]]): HttpTask[R]
 }

--- a/refuel-json/src/main/scala/refuel/json/JsonTransform.scala
+++ b/refuel-json/src/main/scala/refuel/json/JsonTransform.scala
@@ -82,4 +82,6 @@ trait JsonTransform {
     def jsonTree: JsonVal = new JsonTransformRouter(t).jsonTree
   }
 
+  protected implicit final def autoReadRaiser[T](read: Read[T]): Codec[T]    = read.raise
+  protected implicit final def autoWriteRaiser[T](write: Write[T]): Codec[T] = write.raise
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
@@ -1,0 +1,8 @@
+package refuel.json.codecs
+
+import refuel.internal.json.CaseCodecFactory
+import refuel.json.Codec
+
+object AutoDerive {
+  implicit def autoDerivation[T]: Codec[T] = macro CaseCodecFactory.fromCaseClass[T]
+}

--- a/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
@@ -4,5 +4,5 @@ import refuel.internal.json.CaseCodecFactory
 import refuel.json.Codec
 
 object AutoDerive {
-  implicit def autoDerivation[T]: Codec[T] = macro CaseCodecFactory.fromCaseClass[T]
+  implicit def autoDerivation[T]: Codec[T] = macro CaseCodecFactory.fromInferOrCase[T]
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/CBuildComp.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/CBuildComp.scala
@@ -19,7 +19,7 @@ private[json] abstract class CBuildComp[A: Codec] {
     ConstCodec.from(k)(apl)(upl)
   }
 
-  def ++[Z](that: CBuildComp[Z]): CBuildComp2[A, Z] = {
+  def ~[Z](that: CBuildComp[Z]): CBuildComp2[A, Z] = {
     implicit val newc: Codec[Z] = that._c
     new CBuildComp2(this, that)
   }
@@ -32,7 +32,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp3[A, B, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp3[A, B, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp3(a, b, that)
     }
@@ -43,7 +43,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp4[A, B, C, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp4[A, B, C, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp4(a, b, c, that)
     }
@@ -59,7 +59,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp5[A, B, C, D, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp5[A, B, C, D, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp5(a, b, c, d, that)
     }
@@ -76,7 +76,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp6[A, B, C, D, E, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp6[A, B, C, D, E, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp6(a, b, c, d, e, that)
     }
@@ -94,7 +94,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp7[A, B, C, D, E, F, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp7[A, B, C, D, E, F, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp7(a, b, c, d, e, f, that)
     }
@@ -113,7 +113,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp8[A, B, C, D, E, F, G, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp8[A, B, C, D, E, F, G, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp8(a, b, c, d, e, f, g, that)
     }
@@ -133,7 +133,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp9[A, B, C, D, E, F, G, H, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp9[A, B, C, D, E, F, G, H, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp9(a, b, c, d, e, f, g, h, that)
     }
@@ -154,7 +154,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp10[A, B, C, D, E, F, G, H, I, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp10[A, B, C, D, E, F, G, H, I, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp10(a, b, c, d, e, f, g, h, i, that)
     }
@@ -178,7 +178,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp11[A, B, C, D, E, F, G, H, I, J, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp11[A, B, C, D, E, F, G, H, I, J, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp11(a, b, c, d, e, f, g, h, i, j, that)
     }
@@ -215,7 +215,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp12[A, B, C, D, E, F, G, H, I, J, K, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp12[A, B, C, D, E, F, G, H, I, J, K, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp12(a, b, c, d, e, f, g, h, i, j, k, that)
     }
@@ -254,7 +254,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k, l.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp13[A, B, C, D, E, F, G, H, I, J, K, L, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp13[A, B, C, D, E, F, G, H, I, J, K, L, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp13(a, b, c, d, e, f, g, h, i, j, k, l, that)
     }
@@ -295,7 +295,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k, l.k, m.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp14[A, B, C, D, E, F, G, H, I, J, K, L, M, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp14[A, B, C, D, E, F, G, H, I, J, K, L, M, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp14(a, b, c, d, e, f, g, h, i, j, k, l, m, that)
     }
@@ -338,7 +338,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k, l.k, m.k, n.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp15[A, B, C, D, E, F, G, H, I, J, K, L, M, N, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp15(a, b, c, d, e, f, g, h, i, j, k, l, m, n, that)
     }
@@ -383,7 +383,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k, l.k, m.k, n.k, o.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp16[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp16(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, that)
     }
@@ -430,7 +430,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k, l.k, m.k, n.k, o.k, p.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp17[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp17(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, that)
     }
@@ -479,7 +479,7 @@ object CBuildComp {
       ConstCodec.from(a.k, b.k, c.k, d.k, e.k, f.k, g.k, h.k, i.k, j.k, k.k, l.k, m.k, n.k, o.k, p.k, q.k)(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp18[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp18(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, that)
     }
@@ -532,7 +532,7 @@ object CBuildComp {
       )
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp19[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp19(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, that)
     }
@@ -587,7 +587,7 @@ object CBuildComp {
       )(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp20[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp20(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, that)
     }
@@ -663,7 +663,7 @@ object CBuildComp {
       )(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp21[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp21(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, that)
     }
@@ -742,7 +742,7 @@ object CBuildComp {
       )(apl)(upl)
     }
 
-    def ++[Z](that: CBuildComp[Z]): CBuildComp22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z] = {
+    def ~[Z](that: CBuildComp[Z]): CBuildComp22[A, B, C, D, E, F, G, H, I, J, K, L, M, N, O, P, Q, R, S, T, U, Z] = {
       implicit val newc: Codec[Z] = that._c
       new CBuildComp22(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, that)
     }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
@@ -1,5 +1,6 @@
 package refuel.json.codecs.builder.context
 
+import refuel.internal.json.CaseCodecFactory
 import refuel.json.codecs.builder.context.keylit.NatureKeyRef
 import refuel.json.codecs.builder.context.translation.{
   IterableCodecTranslator,
@@ -27,9 +28,11 @@ trait CodecBuildFeature
     */
   protected implicit def __jsonKeyLiteralBuild(v: String): NatureKeyRef = NatureKeyRef(v)
 
+  protected implicit def __serializeToConst[T](v: Codec[T]): T => JsonVal = v.serialize
   protected implicit def __serializeToConst[T](v: Write[T]): T => JsonVal = v.serialize
 
-  protected implicit def __deserializeToConst[T](v: Read[T]): JsonVal => T = v.deserialize
+  protected implicit def __deserializeToConst[T](v: Codec[T]): JsonVal => T = v.deserialize
+  protected implicit def __deserializeToConst[T](v: Read[T]): JsonVal => T  = v.deserialize
 
   protected implicit def __jsonBuildCriteria[V](v: V)(implicit c: Codec[V]): JsonVal = c.serialize(v)
 }

--- a/refuel-json/src/test/scala/refuel/json/codecs/builder/CBuildCompTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/builder/CBuildCompTest.scala
@@ -42,9 +42,9 @@ class CBuildCompTest extends AsyncWordSpec with Matchers with Diagrams with Json
     implicit val CodecC: Codec[C] = "root"
       .parsed(
         {
-          "1/4".parsed(CodecA) ++
-          "2/4".parsed(CodecA) ++
-          "3/4".parsed(option(CodecAA)) ++
+          "1/4".parsed(CodecA) ~
+          "2/4".parsed(CodecA) ~
+          "3/4".parsed(option(CodecAA)) ~
           "4/4".parsed(option(CodecAA))
         }.apply(B.apply)(B.unapply)
       )
@@ -77,19 +77,20 @@ class CBuildCompTest extends AsyncWordSpec with Matchers with Diagrams with Json
     }
 
     def buildLiteralCodecDep2A(pattern: Int): Codec[Depth2LineA] = pattern match {
-      case 1 =>
+      case 1 => {
         "1/4".parsed(
           {
-            buildLiteralCodecDep3A(1) ++
-            buildLiteralCodecDep3A(2) ++
+            buildLiteralCodecDep3A(1) ~
+            buildLiteralCodecDep3A(2) ~
             option(buildLiteralCodecDep3A(3))
           }.apply(Depth2LineA.apply)(Depth2LineA.unapply)
         )
+      }
       case 2 =>
         "2/4".parsed(
           {
-            buildLiteralCodecDep3A(1) ++
-            buildLiteralCodecDep3A(2) ++
+            buildLiteralCodecDep3A(1) ~
+            buildLiteralCodecDep3A(2) ~
             option(buildLiteralCodecDep3A(3))
           }.apply(Depth2LineA.apply)(Depth2LineA.unapply)
         )
@@ -107,9 +108,9 @@ class CBuildCompTest extends AsyncWordSpec with Matchers with Diagrams with Json
     }
 
     implicit val rootCodec: Codec[Depth1] = "root".parsed(
-      (buildLiteralCodecDep2A(1) ++
-      buildLiteralCodecDep2A(2) ++
-      option(buildLiteralCodecDep2B(1)) ++
+      (buildLiteralCodecDep2A(1) ~
+      buildLiteralCodecDep2A(2) ~
+      option(buildLiteralCodecDep2B(1)) ~
       option(buildLiteralCodecDep2B(2))).apply(Depth1.apply)(Depth1.unapply)
     )
 
@@ -160,9 +161,9 @@ class CBuildCompTest extends AsyncWordSpec with Matchers with Diagrams with Json
     val CodecAA = CaseClassCodec.from[AA]
 
     val CodecB = {
-      "1/4".parsed(CodecA) ++
-      "2/4".parsed(CodecA) ++
-      "3/4".parsed(option(CodecAA)) ++
+      "1/4".parsed(CodecA) ~
+      "2/4".parsed(CodecA) ~
+      "3/4".parsed(option(CodecAA)) ~
       "4/4".parsed(option(CodecAA))
     }.apply(B.apply)(B.unapply)
 
@@ -205,7 +206,7 @@ class CBuildCompTest extends AsyncWordSpec with Matchers with Diagrams with Json
 
     val codec = "root".parsed(
       {
-        ConstCodec.from("test1", "test2", "test5", "test6")(String4.apply)(String4.unapply) ++
+        ConstCodec.from("test1", "test2", "test5", "test6")(String4.apply)(String4.unapply) ~
         option(ConstCodec.from("test3", "test4", "test7", "test8")(String4.apply)(String4.unapply))
       }.apply(String4_2.apply)(String4_2.unapply)
     )
@@ -245,9 +246,9 @@ class CBuildCompTest extends AsyncWordSpec with Matchers with Diagrams with Json
          |""".stripMargin
 
     val codec: Codec[(String, String, String, Option[String])] = {
-      ("root" @@ "test1").apply[String] ++
-      ("root" @@ "test2")[String] ++
-      ("root" @@ "test3")[String] ++
+      ("root" @@ "test1").apply[String] ~
+      ("root" @@ "test2")[String] ~
+      ("root" @@ "test3")[String] ~
       option(("root" @@ "test8")[String])
     }.apply((a, b, c, d) => (a, b, c, d))(x => Some(x))
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.3-SNAPSHOT"
+version in ThisBuild := "1.2.3"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.2"
+version in ThisBuild := "1.2.3-SNAPSHOT"


### PR DESCRIPTION
## Support exception handling in HTTP tasks

If HTTP status indicates an error, Future will not fail.
However, response status errors and exceptions such as connections can now be handled together by handling exceptions with validStatus and recover.

Pickup will recover a Future that has received an abnormal status and failed.
However, it does not pickup any failures other than receiving an anomaly value.

```scala
http[GET](url)
  .map(???)
  .pickup
  .recover {
    case e => ???
  }
  .recoverF {
    case e => Future.failed(???)
  }
  . recoverWith {
    case e => http[GET](url).run
  }
```

## Added AutoDerive.
By importing this, it is possible to auto-guess the top-level codec as well.
We were able to guess the CaseClass and the codecs inside more than one level, but the top-level codecs had to be explicitly stated.

```scala
object Codecs extends CodecDef {
  implicit val codec: MyID = CaseClassCodec.from[MyID]
}

object Main extends JsonTransform {
  import Codecs._
  val result: Seq[MyID] = Nil

  val serialized: String = result // Seq[MyID]'s Codec was only automatically guessed by inheriting CodecDef.
}
```

Import `AutoDerive._` from here onwards to guess all codecs is possible.

### Be careful with the implicit scope.
AutoDerive will try to guess all the codecs except the scope that has priority over import scope. This may result in duplicate implicit codecs or the use of unintended codecs, depending on the implementation.