### PR TITLE
Implements lazy primary constructor injection

### DIFF
--- a/refuel-container/src/main/scala/refuel/container/DefaultContainer.scala
+++ b/refuel-container/src/main/scala/refuel/container/DefaultContainer.scala
@@ -65,10 +65,6 @@ private[refuel] class DefaultContainer private (val lights: Vector[Container] = 
     _buffer.snapshot().get(ContainerIndexedKey(tpe)) match {
       case None => None
       case Some(r) =>
-        val xx = r
-          .filter(x => x.c == this && x.accepted(requestFrom))
-          .toSeq
-          .sortBy(_.priority)(InjectionPriority.Order)
         r.filter(x => x.c == this && x.accepted(requestFrom))
           .toSeq
           .sortBy(_.priority)(InjectionPriority.Order)

--- a/refuel-container/src/main/scala/refuel/container/DefaultContainer.scala
+++ b/refuel-container/src/main/scala/refuel/container/DefaultContainer.scala
@@ -65,6 +65,10 @@ private[refuel] class DefaultContainer private (val lights: Vector[Container] = 
     _buffer.snapshot().get(ContainerIndexedKey(tpe)) match {
       case None => None
       case Some(r) =>
+        val xx = r
+          .filter(x => x.c == this && x.accepted(requestFrom))
+          .toSeq
+          .sortBy(_.priority)(InjectionPriority.Order)
         r.filter(x => x.c == this && x.accepted(requestFrom))
           .toSeq
           .sortBy(_.priority)(InjectionPriority.Order)

--- a/refuel-container/src/main/scala/refuel/injector/MetaMediation.scala
+++ b/refuel-container/src/main/scala/refuel/injector/MetaMediation.scala
@@ -80,11 +80,10 @@ private[refuel] trait MetaMediation[C <: Container] extends CanBeContainer[C] {
     *
     * The type information is resolved at compile time, but the injection object is finalized at runtime.
     *
-    * @param ctn    Container
     * @param access Accessor (This refers to itself)
     * @tparam T Injection type
     * @return
     */
-  protected def inject[T](implicit ctn: C, ip: InjectionPool, access: Accessor[_]): Lazy[T] =
+  protected def inject[T](implicit ip: InjectionPool, access: Accessor[_]): Lazy[T] =
     macro Macro.lazyInject[T]
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
@@ -3,7 +3,9 @@ package refuel.json.codecs
 import refuel.internal.json.CaseCodecFactory
 import refuel.json.{Codec, JsonVal}
 
-object AutoDerive {
+object AutoDerive extends AutoDerive
+
+trait AutoDerive {
   implicit def autoDerivation[T]: Codec[T] = macro CaseCodecFactory.fromInferOrCase[T]
 
   implicit def __as[V](v: V)(implicit c: Write[V]): JsonVal = c.serialize(v)

--- a/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/AutoDerive.scala
@@ -1,8 +1,10 @@
 package refuel.json.codecs
 
 import refuel.internal.json.CaseCodecFactory
-import refuel.json.Codec
+import refuel.json.{Codec, JsonVal}
 
 object AutoDerive {
   implicit def autoDerivation[T]: Codec[T] = macro CaseCodecFactory.fromInferOrCase[T]
+
+  implicit def __as[V](v: V)(implicit c: Write[V]): JsonVal = c.serialize(v)
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/JoinableCodec.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/JoinableCodec.scala
@@ -6,6 +6,16 @@ import refuel.json.{Codec, JsonVal}
 
 object JoinableCodec {
 
+  class T0[A, Z](apl: A => Z)(upl: Z => Option[A])(implicit n1: Codec[A]) extends Codec[Z] {
+    override def serialize(t: Z): JsonVal = upl(t).fold[JsonVal](JsNull) { x => n1.serialize(x) }
+
+    override def deserialize(bf: JsonVal): Z = {
+      apl(
+        n1.deserialize(bf)
+      )
+    }
+  }
+
   class T1[A, Z](s1: JsonKeyRef)(apl: A => Z)(upl: Z => Option[A])(implicit n1: Codec[A]) extends Codec[Z] {
     override def serialize(t: Z): JsonVal = upl(t).fold[JsonVal](JsNull) { x =>
       JsObject.fromEntry(

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
@@ -1,6 +1,6 @@
 package refuel.json.codecs.builder.context
 
-import refuel.json.JsonVal
+import refuel.json.{Codec, JsonVal}
 import refuel.json.codecs.builder.context.keylit.NatureKeyRef
 import refuel.json.codecs.builder.context.translation.{
   IterableCodecTranslator,
@@ -27,5 +27,6 @@ trait CodecBuildFeature
     */
   protected implicit def __jsonKeyLiteralBuild(v: String): NatureKeyRef = NatureKeyRef(v)
 
-  protected def as[V](v: V)(implicit c: Write[V]): JsonVal = AutoDerive.__as(v)
+  protected implicit def inferedAs[V](v: V)(implicit c: Codec[V]): JsonVal = as(v)
+  protected def as[V](v: V)(implicit c: Write[V]): JsonVal                 = AutoDerive.__as(v)
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
@@ -1,6 +1,5 @@
 package refuel.json.codecs.builder.context
 
-import refuel.internal.json.CaseCodecFactory
 import refuel.json.codecs.builder.context.keylit.NatureKeyRef
 import refuel.json.codecs.builder.context.translation.{
   IterableCodecTranslator,
@@ -34,5 +33,5 @@ trait CodecBuildFeature
   protected implicit def __deserializeToConst[T](v: Codec[T]): JsonVal => T = v.deserialize
   protected implicit def __deserializeToConst[T](v: Read[T]): JsonVal => T  = v.deserialize
 
-  protected implicit def __jsonBuildCriteria[V](v: V)(implicit c: Codec[V]): JsonVal = c.serialize(v)
+  protected implicit def as[V](v: V)(implicit c: Write[V]): JsonVal = c.serialize(v)
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
@@ -1,5 +1,6 @@
 package refuel.json.codecs.builder.context
 
+import refuel.json.JsonVal
 import refuel.json.codecs.builder.context.keylit.NatureKeyRef
 import refuel.json.codecs.builder.context.translation.{
   IterableCodecTranslator,
@@ -7,8 +8,7 @@ import refuel.json.codecs.builder.context.translation.{
   TupleCodecTranslator
 }
 import refuel.json.codecs.builder.context.write.DynamicCodecGenFeature
-import refuel.json.codecs.{Read, Write}
-import refuel.json.{Codec, JsonVal}
+import refuel.json.codecs.{AutoDerive, Write}
 
 import scala.language.implicitConversions
 
@@ -27,11 +27,5 @@ trait CodecBuildFeature
     */
   protected implicit def __jsonKeyLiteralBuild(v: String): NatureKeyRef = NatureKeyRef(v)
 
-  protected implicit def __serializeToConst[T](v: Codec[T]): T => JsonVal = v.serialize
-  protected implicit def __serializeToConst[T](v: Write[T]): T => JsonVal = v.serialize
-
-  protected implicit def __deserializeToConst[T](v: Codec[T]): JsonVal => T = v.deserialize
-  protected implicit def __deserializeToConst[T](v: Read[T]): JsonVal => T  = v.deserialize
-
-  protected implicit def as[V](v: V)(implicit c: Write[V]): JsonVal = c.serialize(v)
+  protected def as[V](v: V)(implicit c: Write[V]): JsonVal = AutoDerive.__as(v)
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/factory/ConstCodec.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/factory/ConstCodec.scala
@@ -17,6 +17,8 @@ import refuel.json.Codec
   * }}}
   */
 private[json] object ConstCodec {
+  def pure[A, Z](apl: A => Z)(upl: Z => Option[A]): Codec[Z] = macro ConstructCodecFactory.fromConst0[A, Z]
+
   def from[A, Z](n1: JsonKeyRef)(apl: A => Z)(upl: Z => Option[A]): Codec[Z] =
     macro ConstructCodecFactory.fromConst1[A, Z]
 

--- a/refuel-json/src/test/scala/refuel/json/CodecDefTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/CodecDefTest.scala
@@ -6,6 +6,8 @@ import org.scalatest.wordspec.AsyncWordSpec
 import refuel.json.codecs.{Read, Write}
 import refuel.json.entry.JsString
 
+import refuel.json.codecs.AutoDerive._
+
 class CodecDefTest extends AsyncWordSpec with Matchers with Diagrams with JsonTransform with CodecDef {
 
   sealed abstract class Animal(name: String)
@@ -34,7 +36,7 @@ class CodecDefTest extends AsyncWordSpec with Matchers with Diagrams with JsonTr
       )
   }
 
-  implicit def animalCodec: Codec[Animal] = Format(animalDeserializer)(animalSerializer)
+  implicit def animalCodec: Codec[Animal] = Format(animalDeserializer.deserialize)(animalSerializer.serialize)
 
   "Parsed by dynamic codec" should {
     "cat" in {

--- a/refuel-json/src/test/scala/refuel/json/CodecDefTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/CodecDefTest.scala
@@ -6,8 +6,6 @@ import org.scalatest.wordspec.AsyncWordSpec
 import refuel.json.codecs.{Read, Write}
 import refuel.json.entry.JsString
 
-import refuel.json.codecs.AutoDerive._
-
 class CodecDefTest extends AsyncWordSpec with Matchers with Diagrams with JsonTransform with CodecDef {
 
   sealed abstract class Animal(name: String)

--- a/refuel-macro/src/main/scala/refuel/container/Container.scala
+++ b/refuel-macro/src/main/scala/refuel/container/Container.scala
@@ -9,7 +9,7 @@ import refuel.injector.scope.{IndexedSymbol, TypedAcceptContext}
 import scala.reflect.runtime.universe
 import scala.reflect.runtime.universe._
 
-private[refuel] trait Container {
+trait Container {
 
   private[refuel] val lights: Vector[Container]
 

--- a/refuel-macro/src/main/scala/refuel/internal/Macro.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/Macro.scala
@@ -15,7 +15,14 @@ class Macro(val c: blackbox.Context) {
     if (prType.<:<(weakTypeOf[Lazy[_]])) {
       reify[Lazy[T]] {
         new Lazy[T] {
-          def _provide(implicit ctn: Container): T = c.Expr[T](q"inject[${prType.dealias.typeArgs.head}]").splice
+          def _provide(implicit ctn: Container): T = c.Expr[T](q"""
+               inject[${prType.dealias.typeArgs.head}] match {
+                 case x: refuel.injector.Injector =>
+                   x._cntMutation = ctn
+                   x
+                 case x => x
+               }
+               """).splice
         }
       }
     } else {

--- a/refuel-macro/src/main/scala/refuel/internal/json/ConstructCodecFactory.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/json/ConstructCodecFactory.scala
@@ -14,6 +14,14 @@ class ConstructCodecFactory(override val c: blackbox.Context)
 
   private[this] final val Codecs = q"refuel.json.codecs"
 
+  def fromConst0[A: c.WeakTypeTag, Z](apl: c.Expr[A => Z])(upl: c.Expr[Z => Option[A]]): c.Expr[Codec[Z]] = {
+    c.Expr[Codec[Z]] {
+      q"""
+        new $Codecs.JoinableCodec.T0($apl)($upl)(${recall(weakTypeOf[A])})
+       """
+    }
+  }
+
   def fromConst1[A: c.WeakTypeTag, Z](
       n1: c.Expr[JsonKeyRef]
   )(apl: c.Expr[A => Z])(upl: c.Expr[Z => Option[A]]): c.Expr[Codec[Z]] = {

--- a/refuel-macro/src/main/scala/refuel/provider/Lazy.scala
+++ b/refuel-macro/src/main/scala/refuel/provider/Lazy.scala
@@ -1,5 +1,7 @@
 package refuel.provider
 
+import refuel.container.Container
+
 trait Lazy[X] {
 
   /**
@@ -7,5 +9,5 @@ trait Lazy[X] {
     *
     * @return
     */
-  def _provide: X
+  def _provide(implicit ctn: Container): X
 }

--- a/refuel-macro/src/main/scala/refuel/provider/package.scala
+++ b/refuel-macro/src/main/scala/refuel/provider/package.scala
@@ -1,5 +1,7 @@
 package refuel
 
+import refuel.container.Container
+
 import scala.language.implicitConversions
 
 package object provider {
@@ -13,7 +15,11 @@ package object provider {
     * @tparam X Variable type
     * @return
     */
-  implicit def _implicitProviding[X](variable: Lazy[X]): X = {
+  implicit def _implicitProviding[X](variable: Lazy[X])(implicit ctn: Container): X = {
+    variable._provide
+  }
+
+  implicit def _implicitNestedProviding[X](variable: Lazy[Lazy[X]])(implicit ctn: Container): X = {
     variable._provide
   }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.0-SNAPSHOT"
+version in ThisBuild := "1.3.0"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.2.3"
+version in ThisBuild := "1.3.0-SNAPSHOT"


### PR DESCRIPTION
## Supports the creation of a pure wrapper codec for an existing codec.

Pure wrapper codecs seemed to require explicitly defining the interconversion in Format.
```scala
implicit val codec: Codec[MyName] = Format { json =>
  MyName(json.to[String])
} { t =>
  implicitly[Codec[String]].serialize(t)
}
```
This is so redundant that it allows a simple wrap in ConstCodec to be used.

```scala
implicit val codec: Codec[MyName] = ConstCodec.pure(MyName.apply)(MyName.unapply)
```

## Supports primary constructor injections that are evaluated at any time.

In the case of primary constructor injection, even classes that provide long-lived behavior are evaluated and immutable instances are created.
It is incompatible with localized DI Scope and therefore supports injections that are evaluated every time they are accessed.

~ v1.2.3
```scala
class A(b: B) extends AutoInject
class B(c: C) extends AutoInject
class C() extends AutoInject {
  val value = 1
}

val a = inject[A]
a.b.c.value // will be 1
shade { implicit ctn =>
  new B(new C() {
    override val value = 2
  }).index(Overwrite)
  a.b.c.value // will be 1
}
```


v1.3.0 ~
```scala
class A(b: Lazy[B]) extends AutoInject // Importante!!
class B(c: C) extends AutoInject
class C() extends AutoInject {
  val value = 1
}

val a = inject[A]
a.b.c.value // will be 1
shade { implicit ctn =>
  new B(new C() {
    override val value = 2
  }).index(Overwrite)
  a.b.c.value // will be 2
 // Because the member b of class A is `Lazy[B]`, it is evaluated on access
}
```
