### PR TITLE
v1.3.7

### DIFF
--- a/refuel-http/src/main/scala/refuel/http/io/HttpFailed.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpFailed.scala
@@ -2,12 +2,13 @@ package refuel.http.io
 
 import akka.http.scaladsl.model.HttpResponse
 
-sealed class HttpRequestFailed[T](val entry: T) extends Throwable
+sealed class HttpRequestFailed[T](val entry: T, cause: Throwable = null) extends RuntimeException(cause)
 
 case class HttpResponseError[T](override val entry: T, response: HttpResponse) extends HttpRequestFailed[T](entry) {
   override def getMessage: String = s"Http request failed. status code: ${response.status.value}"
 }
 
-case class HttpErrorRaw(override val entry: HttpResponse) extends HttpRequestFailed[HttpResponse](entry) {
+case class HttpErrorRaw(override val entry: HttpResponse, cause: Throwable = null)
+    extends HttpRequestFailed[HttpResponse](entry, cause) {
   override def getMessage: String = s"Http request failed. status code: ${entry.status.value}"
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/All.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/All.scala
@@ -2,8 +2,8 @@ package refuel.json.codecs
 
 import refuel.json.codecs.builder.context.CodecBuildFeature
 import refuel.json.{Codec, JsonVal}
-import refuel.json.codecs.definition.{AnyRefCodecsExport, AnyValCodecs, TupleCodecsImpl}
+import refuel.json.codecs.definition.{AnyRefCodecsExplicit, AnyValCodecs, TupleCodecsImpl}
 
-private[json] trait All extends AnyValCodecs with AnyRefCodecsExport with TupleCodecsImpl { _: CodecBuildFeature =>
+private[json] trait All extends AnyValCodecs with AnyRefCodecsExplicit with TupleCodecsImpl { _: CodecBuildFeature =>
   implicit val JsonCodec: Codec[JsonVal] = Format(x => x)(x => x)
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/EitherCodecConditionBuilder.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/EitherCodecConditionBuilder.scala
@@ -1,0 +1,8 @@
+package refuel.json.codecs.builder
+
+import refuel.json.JsonVal
+import refuel.json.codecs.CodecRaiseable
+
+class EitherCodecConditionBuilder[L, R, C[_] <: CodecRaiseable[_]](v: (JsonVal => Boolean) => C[Either[L, R]]) {
+  def cond(f: JsonVal => Boolean): C[Either[L, R]] = v(f)
+}

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/DynamicCodecGenFeature.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/DynamicCodecGenFeature.scala
@@ -18,5 +18,4 @@ trait DynamicCodecGenFeature {
   def BothWith[T](key: JsonKeyRef)(implicit codec: Codec[T]): Codec[T] = {
     implicitly[CodecTyper[Codec]].wrap(key)(codec)
   }
-
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/translation/IterableCodecTranslator.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/translation/IterableCodecTranslator.scala
@@ -1,29 +1,41 @@
 package refuel.json.codecs.builder.context.translation
 
 import refuel.json.Codec
-import refuel.json.codecs.definition.AnyRefCodecs
+import refuel.json.codecs.builder.EitherCodecConditionBuilder
+import refuel.json.codecs.definition.AnyRefCodecsExplicit
 import refuel.json.codecs.{Read, Write}
 
 import scala.reflect.ClassTag
 
-trait IterableCodecTranslator extends AnyRefCodecs {
-  protected def set[T](implicit codec: Read[T]): Read[Set[T]]   = SetCodec(codec)
-  protected def set[T](implicit codec: Write[T]): Write[Set[T]] = codec
-  protected def set[T](implicit codec: Codec[T]): Codec[Set[T]] = codec
+trait IterableCodecTranslator extends AnyRefCodecsExplicit {
+  protected final def set[T](implicit codec: Read[T]): Read[Set[T]]   = SetCodec(codec)
+  protected final def set[T](implicit codec: Write[T]): Write[Set[T]] = codec
+  protected final def set[T](implicit codec: Codec[T]): Codec[Set[T]] = codec
 
-  protected def seq[T](implicit codec: Read[T]): Read[Seq[T]]   = codec
-  protected def seq[T](implicit codec: Write[T]): Write[Seq[T]] = codec
-  protected def seq[T](implicit codec: Codec[T]): Codec[Seq[T]] = codec
+  protected final def seq[T](implicit codec: Read[T]): Read[Seq[T]]   = codec
+  protected final def seq[T](implicit codec: Write[T]): Write[Seq[T]] = codec
+  protected final def seq[T](implicit codec: Codec[T]): Codec[Seq[T]] = codec
 
-  protected def vector[T](implicit codec: Read[T]): Read[Vector[T]]   = codec
-  protected def vector[T](implicit codec: Write[T]): Write[Vector[T]] = codec
-  protected def vector[T](implicit codec: Codec[T]): Codec[Vector[T]] = codec
+  protected final def vector[T](implicit codec: Read[T]): Read[Vector[T]]   = codec
+  protected final def vector[T](implicit codec: Write[T]): Write[Vector[T]] = codec
+  protected final def vector[T](implicit codec: Codec[T]): Codec[Vector[T]] = codec
 
-  protected def array[T: ClassTag](implicit codec: Read[T]): Read[Array[T]]   = codec
-  protected def array[T: ClassTag](implicit codec: Write[T]): Write[Array[T]] = codec
-  protected def array[T: ClassTag](implicit codec: Codec[T]): Codec[Array[T]] = codec
+  protected final def array[T: ClassTag](implicit codec: Read[T]): Read[Array[T]]   = codec
+  protected final def array[T: ClassTag](implicit codec: Write[T]): Write[Array[T]] = codec
+  protected final def array[T: ClassTag](implicit codec: Codec[T]): Codec[Array[T]] = codec
 
-  protected def option[T](implicit codec: Read[T]): Read[Option[T]]   = codec
-  protected def option[T](implicit codec: Write[T]): Write[Option[T]] = codec
-  protected def option[T](implicit codec: Codec[T]): Codec[Option[T]] = codec
+  protected final def option[T](implicit codec: Read[T]): Read[Option[T]]   = codec
+  protected final def option[T](implicit codec: Write[T]): Write[Option[T]] = codec
+  protected final def option[T](implicit codec: Codec[T]): Codec[Option[T]] = codec
+
+  protected final def either[L, R](implicit lc: Codec[L], rc: Codec[R]): Codec[Either[L, R]] = EitherCodec
+  protected final def either[L, R](implicit lc: Read[L], rc: Read[R]): Read[Either[L, R]]    = EitherCodec
+  protected final def either[L, R](implicit lc: Write[L], rc: Write[R]): Write[Either[L, R]] = EitherCodec
+
+  protected final def eitherCond[L, R](implicit lc: Codec[L], rc: Codec[R]): EitherCodecConditionBuilder[L, R, Codec] =
+    new EitherCodecConditionBuilder[L, R, Codec](EitherCondCodec(_))
+  protected final def eitherCond[L, R](implicit lc: Read[L], rc: Read[R]): EitherCodecConditionBuilder[L, R, Read] =
+    new EitherCodecConditionBuilder[L, R, Read](EitherCondCodec(_))
+  protected final def eitherCond[L, R](implicit lc: Write[L], rc: Write[R]): EitherCodecConditionBuilder[L, R, Write] =
+    new EitherCodecConditionBuilder[L, R, Write](EitherCondCodec(_))
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyRefCodecsExplicit.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyRefCodecsExplicit.scala
@@ -1,6 +1,8 @@
 package refuel.json.codecs.definition
 
 import refuel.json.Codec
+import refuel.json.codecs.builder.EitherCodecConditionBuilder
+import refuel.json.codecs.{Read, Write}
 
 import scala.reflect.ClassTag
 
@@ -10,7 +12,7 @@ import scala.reflect.ClassTag
   * On the other hand, AnyRefCodecImpl is a wrapper to automatically derive recursive AnyRefCodec.
   *
   */
-trait AnyRefCodecsExport extends AnyRefCodecs {
+trait AnyRefCodecsExplicit extends AnyRefCodecs {
 
   /**
     * [[Seq]] codec generator.
@@ -20,6 +22,10 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
     */
   implicit final def SeqCodecImpl[T: Codec]: Codec[Seq[T]] = SeqCodec(implicitly[Codec[T]])
 
+  implicit final def SeqReadImpl[T: Read]: Read[Seq[T]] = SeqCodec(implicitly[Read[T]])
+
+  implicit final def SeqWriteImpl[T: Write]: Write[Seq[T]] = SeqCodec(implicitly[Write[T]])
+
   /**
     * [[Set]] codec generator.
     *
@@ -27,6 +33,10 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
     * @return
     */
   implicit final def SetCodecImpl[T: Codec]: Codec[Set[T]] = SetCodec(implicitly[Codec[T]])
+
+  implicit final def SetReadImpl[T: Read]: Read[Set[T]] = SetCodec(implicitly[Read[T]])
+
+  implicit final def SetWriteImpl[T: Write]: Write[Set[T]] = SetCodec(implicitly[Write[T]])
 
   /**
     * [[Vector]] codec generator.
@@ -36,6 +46,10 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
     */
   implicit final def VectorCodecImpl[T: Codec]: Codec[Vector[T]] = VectorCodec(implicitly[Codec[T]])
 
+  implicit final def VectorReadImpl[T: Read]: Read[Vector[T]] = VectorCodec(implicitly[Read[T]])
+
+  implicit final def VectorWriteImpl[T: Write]: Write[Vector[T]] = VectorCodec(implicitly[Write[T]])
+
   /**
     * [[Array]] codec generator.
     *
@@ -44,6 +58,10 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
     */
   implicit final def ArrayCodecImpl[T: Codec: ClassTag]: Codec[Array[T]] = ArrayCodec(implicitly[Codec[T]])
 
+  implicit final def ArrayReadImpl[T: Read: ClassTag]: Read[Array[T]] = ArrayCodec(implicitly[Read[T]])
+
+  implicit final def ArrayWriteImpl[T: Write: ClassTag]: Write[Array[T]] = ArrayCodec(implicitly[Write[T]])
+
   /**
     * [[List]] codec generator.
     *
@@ -51,6 +69,10 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
     * @return
     */
   implicit final def ListCodecImpl[T: Codec]: Codec[List[T]] = ListCodec(implicitly[Codec[T]])
+
+  implicit final def ListReadImpl[T: Read]: Read[List[T]] = ListCodec(implicitly[Read[T]])
+
+  implicit final def ListWriteImpl[T: Write]: Write[List[T]] = ListCodec(implicitly[Write[T]])
 
   /**
     * [[Map]] codec generator.
@@ -62,6 +84,12 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
   implicit final def MapCodecImpl[K: Codec, V: Codec]: Codec[Map[K, V]] =
     MapCodec(implicitly[Codec[K]] -> implicitly[Codec[V]])
 
+  implicit final def MapCodecImpl[K: Read, V: Read]: Read[Map[K, V]] =
+    MapCodec(implicitly[Read[K]] -> implicitly[Read[V]])
+
+  implicit final def MapCodecImpl[K: Write, V: Write]: Write[Map[K, V]] =
+    MapCodec(implicitly[Write[K]] -> implicitly[Write[V]])
+
   /**
     * [[Option]] codec generator.
     *
@@ -69,4 +97,8 @@ trait AnyRefCodecsExport extends AnyRefCodecs {
     * @return
     */
   implicit final def OptionCodecImpl[T: Codec]: Codec[Option[T]] = OptionCodec(implicitly[Codec[T]])
+
+  implicit final def OptionCodecImpl[T: Read]: Read[Option[T]] = OptionCodec(implicitly[Read[T]])
+
+  implicit final def OptionCodecImpl[T: Write]: Write[Option[T]] = OptionCodec(implicitly[Write[T]])
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyValCodecs.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyValCodecs.scala
@@ -2,7 +2,7 @@ package refuel.json.codecs.definition
 
 import java.time.ZonedDateTime
 
-import refuel.json.entry.{JsAnyVal, JsNull, JsString}
+import refuel.json.entry.{JsAnyVal, JsEmpty, JsNull, JsString}
 import refuel.json.error.{DeserializeFailed, UnexpectedDeserializeType, UnsupportedOperation}
 import refuel.json.{Codec, JsonVal}
 import refuel.lang.ScalaTime
@@ -10,6 +10,11 @@ import refuel.lang.ScalaTime
 import scala.util.{Failure, Success, Try}
 
 private[codecs] trait AnyValCodecs {
+
+  implicit final val UnitCdc: Codec[Unit] = new Codec[Unit] {
+    override def serialize(t: Unit): JsonVal    = JsEmpty
+    override def deserialize(bf: JsonVal): Unit = ()
+  }
 
   /**
     * The base of scala base api codec.

--- a/refuel-json/src/main/scala/refuel/json/entry/JsEmpty.scala
+++ b/refuel-json/src/main/scala/refuel/json/entry/JsEmpty.scala
@@ -5,6 +5,9 @@ import refuel.json.error.UnexpectedDeserializeOperation
 
 private[refuel] case object JsEmpty extends JsVariable {
 
+  override def isEmpty: Boolean     = true
+  override def isNonEmptry: Boolean = false
+
   override def toString: String   = ""
   def pour(b: StringBuffer): Unit = ()
 

--- a/refuel-json/src/main/scala/refuel/json/entry/JsNull.scala
+++ b/refuel-json/src/main/scala/refuel/json/entry/JsNull.scala
@@ -4,6 +4,10 @@ import refuel.json.JsonVal
 import refuel.json.error.IllegalJsonSyntaxTreeBuilding
 
 case object JsNull extends JsVariable {
+
+  override def isEmpty: Boolean     = true
+  override def isNonEmptry: Boolean = false
+
   override final def toString: String = "null"
   def pour(b: StringBuffer): Unit     = b.append(toString)
 

--- a/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyRefCodecsExplicitTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyRefCodecsExplicitTest.scala
@@ -7,7 +7,7 @@ import refuel.json.codecs.{Read, Write}
 import refuel.json.error.UnsupportedOperation
 import refuel.json.{Codec, CodecDef, Json, JsonTransform}
 
-class AnyRefCodecsExportTest extends AsyncWordSpec with Matchers with Diagrams with JsonTransform with CodecDef {
+class AnyRefCodecsExplicitTest extends AsyncWordSpec with Matchers with Diagrams with JsonTransform with CodecDef {
   "Any ref codec auto generation" should {
     "Expected to be compileable without explicit Codec[_] generation" in {
       implicitly[Codec[Map[String, Option[List[Seq[Vector[Array[Set[(String, String)]]]]]]]]]

--- a/refuel-macro/src/main/scala/refuel/json/JsonVal.scala
+++ b/refuel-macro/src/main/scala/refuel/json/JsonVal.scala
@@ -12,6 +12,14 @@ trait JsonVal extends Serializable {
     buf.toString
   }
 
+  /** Determines that the target JSON syntax tree does not exist or is a null symbol.
+    * Empty arrays and empty objects are not considered to be empty.
+    *
+    * @return
+    */
+  def isEmpty: Boolean     = false
+  def isNonEmptry: Boolean = true
+
   /**
     * Detects hooked binding syntax of Json literal.
     * This detects syntax errors when joining Json objects.

--- a/sh/server.js
+++ b/sh/server.js
@@ -15,6 +15,24 @@ server.get('/success', (req, res) => {
     })
 })
 
+server.get('/200/failed', (req, res) => {
+    res.status(200).jsonp({
+        status: "failed",
+        error: "foo"
+    })
+})
+
+server.get('/200/success', (req, res) => {
+    res.status(200).jsonp({
+        status: "success",
+        value: {
+            id: 90,
+            joke: "Chuck Norris always knows the EXACT location of Carmen SanDiego.",
+            categories: []
+        }
+    })
+})
+
 server.get('/failed', (req, res) => {
     res.status(500).jsonp({
         status: "failed",

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.6"
+version in ThisBuild := "1.3.7"


### PR DESCRIPTION
## Add default json codecs

- Codec[Unit]
- Codec[Either[L, R]]

## Add JSON state judge function.

- JsonVal.isEmpty
- JosnVal.isNonEmpty

Determines that the target JSON syntax tree does not exist or is a null symbol.
Empty arrays and empty objects are not considered to be empty.

## Add http request error handler.

The http request can now be handled not only when it exits with an abnormal status, but also when a normal response is received, according to the response body.

```scala
http[GET](url)
  .transform[SuccessType, FailureType] // Whether http status indicates success or not
  .eitherMap[LeftType, RightType] // Whether the Right process was successful or not
  .eitherTransform[LeftType, RightType, FailureType] // Whether http status indicates success, and whether the process on the Right was successful or not.
```

If you want to control the processing result type by the content of a specific element, you need to define your own Codec[Either[L, R]].
For example, to check the value of status: Boolean to determine if it is Left or Right.

```scala
implicit def _codec1: Read[RIGHT] = ???
implicit def _codec2: Read[LEFT] = ???

implicit def eitherCodec: Read[Either[LEFT, RIGHT]] = eitherCond[LEFT, RIGHT].cond(_.named("status").des[Boolean])

http[GET](url)
  .transform[Either[LEFT, RIGHT], FAILED]
  .run

// {"status": "true", ...} => RIGHT
// {"status": "false", ...} => LEFT
```