### PR TITLE
Fix double unmarshalize bug

### DIFF
--- a/refuel-container/README.md
+++ b/refuel-container/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-container" % "1.3.7"
+libraryDependencies += "com.phylage" %% "refuel-container" % "1.3.8"
 ````
 
 ## Features

--- a/refuel-http/README.md
+++ b/refuel-http/README.md
@@ -4,7 +4,7 @@
 
 ```
 libraryDependencies ++= Seq(
-  "com.phylage"       %% "refuel-http" % "1.3.7",
+  "com.phylage"       %% "refuel-http" % "1.3.8",
   "com.typesafe.akka" %% "akka-stream" % "2.6.4",
   "com.typesafe.akka" %% "akka-http"   % "10.1.11"
 )

--- a/refuel-http/src/main/scala/refuel/http/io/task/StrictTask.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/task/StrictTask.scala
@@ -1,0 +1,28 @@
+package refuel.http.io.task
+
+import akka.actor.ActorSystem
+import akka.http.scaladsl.model.HttpResponse
+import akka.util.ByteString
+import refuel.http.io.setting.HttpSetting
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+
+private[refuel] class StrictTask(response: HttpResponse)(
+    implicit setting: HttpSetting,
+    timeout: FiniteDuration = 30.seconds
+) extends CombineTask[String] {
+
+  /**
+    * Execute future functions.
+    *
+    * @return
+    */
+  override def run(implicit as: ActorSystem): Future[String] = {
+    response.entity
+      .toStrict(timeout)
+      .flatMap(
+        setting.responseBuilder(_).dataBytes.runFold(ByteString.empty)(_ ++ _).map(_.utf8String)(as.dispatcher)
+      )(as.dispatcher)
+  }
+}

--- a/refuel-json/README.md
+++ b/refuel-json/README.md
@@ -1,7 +1,7 @@
 # refuel-json
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-json" % "1.3.7"
+libraryDependencies += "com.phylage" %% "refuel-json" % "1.3.8"
 ```
 
 refuel-json automatically generates codec and supports JSON mutual conversion fast and easy.

--- a/refuel-json/src/main/scala/refuel/json/CodecDef.scala
+++ b/refuel-json/src/main/scala/refuel/json/CodecDef.scala
@@ -1,7 +1,7 @@
 package refuel.json
 
 import refuel.json.codecs.All
-import refuel.json.codecs.builder.context.{CodecBuildFeature, CodecDefinitionContext}
+import refuel.json.codecs.builder.context.CodecBuildFeature
 
 /**
   * Every interface for defining codecs is defined.

--- a/refuel-json/src/main/scala/refuel/json/Json.scala
+++ b/refuel-json/src/main/scala/refuel/json/Json.scala
@@ -1,9 +1,10 @@
 package refuel.json
 
-import refuel.json.entry.{JsArray, JsObject, JsString}
+import refuel.json.entry.{JsArray, JsNull, JsObject, JsString}
 
 object Json {
   def obj(rows: (String, JsonVal)*): JsonVal = JsObject(rows: _*)
   def arr(rows: JsonVal*): JsonVal           = JsArray(rows)
   def str(row: String): JsonVal              = JsString(row)
+  def Null: JsonVal                          = JsNull
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/CodecBuildFeature.scala
@@ -1,6 +1,6 @@
 package refuel.json.codecs.builder.context
 
-import refuel.json.JsonVal
+import refuel.json.{Codec, JsonVal}
 import refuel.json.codecs.builder.DeserializeConcatenation
 import refuel.json.codecs.builder.context.keylit.NatureKeyRef
 import refuel.json.codecs.builder.context.translation.{

--- a/refuel-json/src/main/scala/refuel/json/codecs/builder/context/translation/IterableCodecTranslator.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/builder/context/translation/IterableCodecTranslator.scala
@@ -3,39 +3,61 @@ package refuel.json.codecs.builder.context.translation
 import refuel.json.Codec
 import refuel.json.codecs.builder.EitherCodecConditionBuilder
 import refuel.json.codecs.definition.AnyRefCodecsExplicit
-import refuel.json.codecs.{Read, Write}
+import refuel.json.codecs._
 
 import scala.reflect.ClassTag
 
 trait IterableCodecTranslator extends AnyRefCodecsExplicit {
-  protected final def set[T](implicit codec: Read[T]): Read[Set[T]]   = SetCodec(codec)
-  protected final def set[T](implicit codec: Write[T]): Write[Set[T]] = codec
-  protected final def set[T](implicit codec: Codec[T]): Codec[Set[T]] = codec
+  protected final def pureR[T](implicit codec: Read[T]): Read[T]   = codec
+  protected final def pureW[T](implicit codec: Write[T]): Write[T] = codec
+  protected final def pure[T](codec: Read[T]): Read[T]             = codec
+  protected final def pure[T](codec: Write[T]): Write[T]           = codec
+  protected final def pure[T](implicit codec: Codec[T]): Codec[T]  = codec
 
-  protected final def seq[T](implicit codec: Read[T]): Read[Seq[T]]   = codec
-  protected final def seq[T](implicit codec: Write[T]): Write[Seq[T]] = codec
-  protected final def seq[T](implicit codec: Codec[T]): Codec[Seq[T]] = codec
+  protected final def setR[T](implicit codec: Read[T]): Read[Set[T]]   = SetCodec(codec)
+  protected final def setW[T](implicit codec: Write[T]): Write[Set[T]] = codec
+  protected final def set[T](codec: Read[T]): Read[Set[T]]             = SetCodec(codec)
+  protected final def set[T](codec: Write[T]): Write[Set[T]]           = codec
+  protected final def set[T](implicit codec: Codec[T]): Codec[Set[T]]  = codec
 
-  protected final def vector[T](implicit codec: Read[T]): Read[Vector[T]]   = codec
-  protected final def vector[T](implicit codec: Write[T]): Write[Vector[T]] = codec
-  protected final def vector[T](implicit codec: Codec[T]): Codec[Vector[T]] = codec
+  protected final def seqR[T](implicit codec: Read[T]): Read[Seq[T]]   = codec
+  protected final def seqW[T](implicit codec: Write[T]): Write[Seq[T]] = codec
+  protected final def seq[T](codec: Read[T]): Read[Seq[T]]             = codec
+  protected final def seq[T](codec: Write[T]): Write[Seq[T]]           = codec
+  protected final def seq[T](implicit codec: Codec[T]): Codec[Seq[T]]  = codec
 
-  protected final def array[T: ClassTag](implicit codec: Read[T]): Read[Array[T]]   = codec
-  protected final def array[T: ClassTag](implicit codec: Write[T]): Write[Array[T]] = codec
-  protected final def array[T: ClassTag](implicit codec: Codec[T]): Codec[Array[T]] = codec
+  protected final def vectorR[T](implicit codec: Read[T]): Read[Vector[T]]   = codec
+  protected final def vectorW[T](implicit codec: Write[T]): Write[Vector[T]] = codec
+  protected final def vector[T](codec: Read[T]): Read[Vector[T]]             = codec
+  protected final def vector[T](codec: Write[T]): Write[Vector[T]]           = codec
+  protected final def vector[T](implicit codec: Codec[T]): Codec[Vector[T]]  = codec
 
-  protected final def option[T](implicit codec: Read[T]): Read[Option[T]]   = codec
-  protected final def option[T](implicit codec: Write[T]): Write[Option[T]] = codec
-  protected final def option[T](implicit codec: Codec[T]): Codec[Option[T]] = codec
+  protected final def arrayR[T: ClassTag](implicit codec: Read[T]): Read[Array[T]]   = codec
+  protected final def arrayW[T: ClassTag](implicit codec: Write[T]): Write[Array[T]] = codec
+  protected final def array[T: ClassTag](codec: Read[T]): Read[Array[T]]             = codec
+  protected final def array[T: ClassTag](codec: Write[T]): Write[Array[T]]           = codec
+  protected final def array[T: ClassTag](implicit codec: Codec[T]): Codec[Array[T]]  = codec
 
-  protected final def either[L, R](implicit lc: Codec[L], rc: Codec[R]): Codec[Either[L, R]] = EitherCodec
-  protected final def either[L, R](implicit lc: Read[L], rc: Read[R]): Read[Either[L, R]]    = EitherCodec
-  protected final def either[L, R](implicit lc: Write[L], rc: Write[R]): Write[Either[L, R]] = EitherCodec
+  protected final def optionR[T](implicit codec: Read[T]): Read[Option[T]]   = codec
+  protected final def optionW[T](implicit codec: Write[T]): Write[Option[T]] = codec
+  protected final def option[T](codec: Read[T]): Read[Option[T]]             = codec
+  protected final def option[T](codec: Write[T]): Write[Option[T]]           = codec
+  protected final def option[T](implicit codec: Codec[T]): Codec[Option[T]]  = codec
+
+  protected final def either[L, R](implicit lc: Codec[L], rc: Codec[R]): Codec[Either[L, R]]  = EitherCodec
+  protected final def either[L, R](lc: Read[L], rc: Read[R]): Read[Either[L, R]]              = EitherCodec(lc, rc, ReadMapper)
+  protected final def either[L, R](lc: Write[L], rc: Write[R]): Write[Either[L, R]]           = EitherCodec(lc, rc, WriteMapper)
+  protected final def eitherR[L, R](implicit lc: Read[L], rc: Read[R]): Read[Either[L, R]]    = EitherCodec
+  protected final def eitherW[L, R](implicit lc: Write[L], rc: Write[R]): Write[Either[L, R]] = EitherCodec
 
   protected final def eitherCond[L, R](implicit lc: Codec[L], rc: Codec[R]): EitherCodecConditionBuilder[L, R, Codec] =
     new EitherCodecConditionBuilder[L, R, Codec](EitherCondCodec(_))
   protected final def eitherCond[L, R](implicit lc: Read[L], rc: Read[R]): EitherCodecConditionBuilder[L, R, Read] =
     new EitherCodecConditionBuilder[L, R, Read](EitherCondCodec(_))
   protected final def eitherCond[L, R](implicit lc: Write[L], rc: Write[R]): EitherCodecConditionBuilder[L, R, Write] =
+    new EitherCodecConditionBuilder[L, R, Write](EitherCondCodec(_))
+  protected final def eitherCondR[L, R](implicit lc: Read[L], rc: Read[R]): EitherCodecConditionBuilder[L, R, Read] =
+    new EitherCodecConditionBuilder[L, R, Read](EitherCondCodec(_))
+  protected final def eitherCondW[L, R](implicit lc: Write[L], rc: Write[R]): EitherCodecConditionBuilder[L, R, Write] =
     new EitherCodecConditionBuilder[L, R, Write](EitherCondCodec(_))
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyRefCodecs.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyRefCodecs.scala
@@ -9,7 +9,7 @@ import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.Try
 
-private[codecs] trait AnyRefCodecs {
+private[refuel] trait AnyRefCodecs {
 
   /**
     * Codec base class for classes that inherit iterable.

--- a/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyRefCodecsExplicit.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/definition/AnyRefCodecsExplicit.scala
@@ -1,7 +1,6 @@
 package refuel.json.codecs.definition
 
 import refuel.json.Codec
-import refuel.json.codecs.builder.EitherCodecConditionBuilder
 import refuel.json.codecs.{Read, Write}
 
 import scala.reflect.ClassTag
@@ -101,4 +100,8 @@ trait AnyRefCodecsExplicit extends AnyRefCodecs {
   implicit final def OptionCodecImpl[T: Read]: Read[Option[T]] = OptionCodec(implicitly[Read[T]])
 
   implicit final def OptionCodecImpl[T: Write]: Write[Option[T]] = OptionCodec(implicitly[Write[T]])
+
+  implicit final def EitherCodecImpl[L: Codec, R: Codec]: Codec[Either[L, R]] = EitherCodec[L, R, Codec]
+  implicit final def EitherCodecImpl[L: Read, R: Read]: Read[Either[L, R]]    = EitherCodec[L, R, Read]
+  implicit final def EitherCodecImpl[L: Write, R: Write]: Write[Either[L, R]] = EitherCodec[L, R, Write]
 }

--- a/refuel-json/src/main/scala/refuel/json/codecs/package.scala
+++ b/refuel-json/src/main/scala/refuel/json/codecs/package.scala
@@ -2,4 +2,7 @@ package refuel.json
 
 import refuel.json.codecs.builder.context.CodecDefinitionContext
 
-package object codecs extends CodecDefinitionContext {}
+package object codecs extends CodecDefinitionContext {
+  implicit def __readRef[T](implicit _c: Codec[T]): Read[T]   = _c
+  implicit def __writeRef[T](implicit _c: Codec[T]): Write[T] = _c
+}

--- a/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyRefCodecsExplicitTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyRefCodecsExplicitTest.scala
@@ -15,7 +15,7 @@ class AnyRefCodecsExplicitTest extends AsyncWordSpec with Matchers with Diagrams
     }
 
     "read auto inferred before deserialize" in {
-      seq(implicitly[Read[Seq[String]]]).deserialize(
+      seqR(implicitly[Read[Seq[String]]]).deserialize(
         Json.arr(
           Json.arr("foo", "bar")
         )

--- a/refuel-util/README.md
+++ b/refuel-util/README.md
@@ -1,7 +1,7 @@
 ## refuel-util
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-util" % "1.3.7"
+libraryDependencies += "com.phylage" %% "refuel-util" % "1.3.8"
 ```
 
 ## Usage

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.7"
+version in ThisBuild := "1.3.8"


### PR DESCRIPTION
## Fixed problem with stream unmarshalling again after connection is closed when unmarshalling fails.

```scala
http[GET](url)
  .transform[Either[Int, String], String]
  .run
```

## Fix syntax suger in codec definitions.