### PR TITLE
Fixed a flaw in multiple escaped JSON serializations

### DIFF
--- a/refuel-http/src/main/scala/refuel/http/io/Http.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/Http.scala
@@ -70,7 +70,7 @@ class Http(val setting: Lazy[HttpSetting]) extends Injector with JsonTransform w
             }
             .flatMap { res =>
               if (res.status.isSuccess()) Future(res)(as.dispatcher)
-              else Future.failed(HttpErrorRaw(res))
+              else Future.failed(HttpErrorRaw(res, None))
             }(as.dispatcher)
       }
     )

--- a/refuel-http/src/main/scala/refuel/http/io/HttpFailed.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpFailed.scala
@@ -8,7 +8,7 @@ case class HttpResponseError[T](override val entry: T, response: HttpResponse) e
   override def getMessage: String = s"Http request failed. status code: ${response.status.value}"
 }
 
-case class HttpErrorRaw(override val entry: HttpResponse, cause: Throwable = null)
+case class HttpErrorRaw(override val entry: HttpResponse, strictedSource: Option[String], cause: Throwable = null)
     extends HttpRequestFailed[HttpResponse](entry, cause) {
   override def getMessage: String = s"Http request failed. status code: ${entry.status.value}"
 }

--- a/refuel-http/src/test/scala/refuel/http/io/HttpTest.scala
+++ b/refuel-http/src/test/scala/refuel/http/io/HttpTest.scala
@@ -1,7 +1,6 @@
 package refuel.http.io
 
 import akka.actor.ActorSystem
-import akka.http.scaladsl.model.headers.{Authorization, OAuth2BearerToken}
 import org.scalatest
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.matchers.should.Matchers
@@ -206,8 +205,9 @@ class HttpTest extends AsyncWordSpec with Matchers with Diagrams with Injector w
       http[GET]("http://localhost:3289/failed").asString.run
         .map(_ => fail())
         .recover {
-          case HttpErrorRaw(res, _) =>
+          case HttpErrorRaw(res, x, _) =>
             res.status.intValue() shouldBe 500
+            x shouldBe None
         }
     }
   }
@@ -301,8 +301,16 @@ class HttpTest extends AsyncWordSpec with Matchers with Diagrams with Injector w
         .map(_ => fail())
         .run
         .recover[scalatest.Assertion] {
-          case HttpErrorRaw(res, _) =>
+          case HttpErrorRaw(res, x, _) =>
             res.status.intValue() shouldBe 200
+            x shouldBe Some(s"""{
+                               |  "status": "success",
+                               |  "value": {
+                               |    "id": 90,
+                               |    "joke": "Chuck Norris always knows the EXACT location of Carmen SanDiego.",
+                               |    "categories": []
+                               |  }
+                               |}""".stripMargin)
         }
     }
   }
@@ -363,8 +371,16 @@ class HttpTest extends AsyncWordSpec with Matchers with Diagrams with Injector w
         .map(_ => fail())
         .run
         .recover[scalatest.Assertion] {
-          case HttpErrorRaw(res, _) =>
+          case HttpErrorRaw(res, x, _) =>
             res.status.intValue() shouldBe 200
+            x shouldBe Some(s"""{
+                               |  "status": "success",
+                               |  "value": {
+                               |    "id": 90,
+                               |    "joke": "Chuck Norris always knows the EXACT location of Carmen SanDiego.",
+                               |    "categories": []
+                               |  }
+                               |}""".stripMargin)
         }
     }
   }

--- a/refuel-json/src/main/scala/refuel/json/logging/JsonLoggingStrategy.scala
+++ b/refuel-json/src/main/scala/refuel/json/logging/JsonLoggingStrategy.scala
@@ -1,0 +1,23 @@
+package refuel.json.logging
+
+import com.typesafe.config.ConfigFactory
+import com.typesafe.scalalogging.LazyLogging
+import refuel.json.JsonVal
+
+trait JsonLoggingStrategy extends LazyLogging {
+  private[this] val logEnabled: Boolean = ConfigFactory.defaultApplication().getBoolean("json.logging.enabled")
+
+  def jsonReadLogging(v: String): Unit = {
+    if (logEnabled) {
+      logger.info(s"Json reading: $v")
+    }
+  }
+
+  def jsonWriteLogging(v: => JsonVal): JsonVal = {
+    val res = v
+    if (logEnabled) {
+      logger.info(s"Json writing: $res")
+    }
+    res
+  }
+}

--- a/refuel-json/src/main/scala/refuel/json/logging/JsonLoggingStrategy.scala
+++ b/refuel-json/src/main/scala/refuel/json/logging/JsonLoggingStrategy.scala
@@ -5,7 +5,10 @@ import com.typesafe.scalalogging.LazyLogging
 import refuel.json.JsonVal
 
 trait JsonLoggingStrategy extends LazyLogging {
-  private[this] val logEnabled: Boolean = ConfigFactory.defaultApplication().getBoolean("json.logging.enabled")
+  private[this] val logEnabled: Boolean = {
+    val conf = ConfigFactory.load()
+    if (conf.hasPath("json.logging.enabled")) conf.getBoolean("json.logging.enabled") else false
+  }
 
   def jsonReadLogging(v: String): Unit = {
     if (logEnabled) {

--- a/refuel-json/src/main/scala/refuel/json/tokenize/combinator/ExtensibleIndexWhere.scala
+++ b/refuel-json/src/main/scala/refuel/json/tokenize/combinator/ExtensibleIndexWhere.scala
@@ -8,7 +8,7 @@ abstract class ExtensibleIndexWhere(rs: Array[Char]) {
 
   protected final val length = rs.length
 
-  protected def beEOF: Unit
+  protected def beEOF: Int
 
   @tailrec
   protected final def indexWhere(fn: Char => Boolean): Unit = {

--- a/refuel-json/src/test/resources/application.conf
+++ b/refuel-json/src/test/resources/application.conf
@@ -1,0 +1,1 @@
+json.logging.enabled = true

--- a/refuel-json/src/test/scala/refuel/json/JsonTransformTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/JsonTransformTest.scala
@@ -20,6 +20,16 @@ class JsonTransformTest extends AsyncWordSpec with Matchers with Diagrams with J
         "value" -> s"""test🌏test🌏test"""
       )
     }
+    "Breakline" in {
+      s"""{"value":"foo\\nbar"}""".jsonTree shouldBe Json.obj(
+        "value" -> "foo\nbar"
+      )
+      Json
+        .obj(
+          "value" -> "foo\nbar"
+        )
+        .des[String] shouldBe s"""{"value":"foo\nbar"}"""
+    }
     "fail case - EOF position" in {
       intercept[IllegalJsonFormat] {
         s"""{"value":123"""".jsonTree

--- a/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyRefCodecsTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyRefCodecsTest.scala
@@ -76,7 +76,7 @@ class AnyRefCodecsTest extends AsyncWordSpec with Matchers with Diagrams with Js
     }
     "Option String deserialize ^ escaped 1" in {
       s"""{"value":"bo\\\\\\"d'y"}""".as(CaseClassCodec.from[JOptString]) shouldBe Right {
-        JOptString(Some("bo\\\\\\\"d'y"))
+        JOptString(Some("bo\\\"d'y"))
       }
     }
 

--- a/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyValCodecsTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/codecs/definition/AnyValCodecsTest.scala
@@ -53,13 +53,14 @@ class AnyValCodecsTest extends AsyncWordSpec with Matchers with Diagrams with Js
       }
     }
     "String deserialize ^ escaped 1" in {
+      val x = s"""{"value":"bo\\"d'y"}""".as[JString](CaseClassCodec.from[JString])
       s"""{"value":"bo\\"d'y"}""".as[JString](CaseClassCodec.from[JString]) shouldBe Right {
-        JString("bo\\\"d'y")
+        JString("bo\"d'y")
       }
     }
     "String deserialize ^ escaped 2" in {
       s"""{"value":"bo\\\\\\"d'y"}""".as[JString](CaseClassCodec.from[JString]) shouldBe Right {
-        JString("bo\\\\\\\"d'y")
+        JString("bo\\\"d'y")
       }
     }
 


### PR DESCRIPTION
## Fixed a flaw in multiple escaped JSON serializations

If you use a refuel json as a Request translator, such as an Http Server, and you request a client escaped string (such as \n), the Http Server may multiplex it.
However, refuel json does not decode the multiplexed escaped strings and expands them as an AST without decoding them, so when you look at only the start and end points, it looks like a strange behavior.

## Fixed a bug that prevented Stricted response body from re-marshalling if Http Response Marshalling failed.

Fixed a bug that caused Json Transformation to use the Response stream to close the stream on both success and failure, so there was no way to check the content of the response if an error occurred.
Keep strained response body in HttpErrorRaw.

## Enable Json transformation log output.

```
json.logging.enabled = true
```

You can output the log of marshalling / unmarshalling of json by specifying `json.logging.enabled` in application.conf.