### PR TITLE
Flatten to nested array tree.

### DIFF
--- a/refuel-container/README.md
+++ b/refuel-container/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-container" % "1.3.14"
+libraryDependencies += "com.phylage" %% "refuel-container" % "1.3.15"
 ````
 
 ## Features

--- a/refuel-http/README.md
+++ b/refuel-http/README.md
@@ -4,7 +4,7 @@
 
 ```
 libraryDependencies ++= Seq(
-  "com.phylage"       %% "refuel-http" % "1.3.14",
+  "com.phylage"       %% "refuel-http" % "1.3.15",
   "com.typesafe.akka" %% "akka-stream" % "2.6.4",
   "com.typesafe.akka" %% "akka-http"   % "10.1.11"
 )

--- a/refuel-http/src/main/scala/refuel/http/io/Http.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/Http.scala
@@ -2,17 +2,18 @@ package refuel.http.io
 
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{HttpRequest, HttpResponse, Uri}
+import com.typesafe.scalalogging.LazyLogging
 import refuel.container.Container
 import refuel.domination.Inject
 import refuel.domination.InjectionPriority.Finally
-import refuel.http.io.setting.HttpSetting
 import refuel.http.io.setting.HttpSetting.RecoveredHttpSetting
+import refuel.http.io.setting.{HttpClientLogEnabled, HttpSetting}
 import refuel.http.io.task.execution.HttpResultExecution
 import refuel.injector.{AutoInject, Injector}
 import refuel.json.JsonTransform
 import refuel.provider.Lazy
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 import scala.language.implicitConversions
 
 @deprecated("Instead, use dependency injection")
@@ -32,7 +33,7 @@ object Http
   * }}}
   */
 @Inject(Finally)
-class Http(val setting: Lazy[HttpSetting]) extends Injector with JsonTransform with AutoInject {
+class Http(val setting: Lazy[HttpSetting]) extends Injector with JsonTransform with AutoInject with LazyLogging {
 
   implicit def __setting: HttpSetting = setting
 
@@ -57,21 +58,46 @@ class Http(val setting: Lazy[HttpSetting]) extends Injector with JsonTransform w
     * @tparam T Request method type. See [[refuel.http.io.HttpMethod]]
     * @return
     */
-  def http[T <: HttpMethod.Method: MethodType](uri: Uri): HttpRunner[HttpResponse] = {
+  def http[T <: HttpMethod.Method: MethodType](
+      uri: Uri
+  )(
+      implicit logging: HttpClientLogEnabled = HttpClientLogEnabled.Default
+  ): HttpRunner[HttpResponse] = {
     new HttpRunner[HttpResponse](
       setting.requestBuilder(
         HttpRequest(implicitly[MethodType[T]].method).withUri(uri)
       ),
       new HttpResultExecution[HttpResponse] {
-        def execute(request: HttpRequest)(implicit as: ActorSystem): Future[HttpResponse] =
-          HttpRetryRevolver(setting.retryThreshold)
-            .revolving() {
-              akka.http.scaladsl.Http().singleRequest(request)
+        def execute(request: HttpRequest)(implicit as: ActorSystem): Future[HttpResponse] = {
+          implicit val ec: ExecutionContext = as.dispatcher
+          (
+            if (logging.enabled) {
+              request.entity.dataBytes
+                .runReduce(_ ++ _)
+                .map(_.utf8String)
+                .map { req =>
+                  logger.info(s"Try to request ${request.method.value}: ${request.uri.toString()} => $req")
+                }
+            } else Future.unit
+          ).map(_ => System.currentTimeMillis())
+            .flatMap {
+              from =>
+                HttpRetryRevolver(setting.retryThreshold)
+                  .revolving() {
+                    akka.http.scaladsl.Http().singleRequest(request)
+                  }
+                  .flatMap { res =>
+                    if (logging.enabled) {
+                      logger.info(
+                        s"Http request completed. ${(System
+                          .currentTimeMillis() - from).toFloat / 1000} sec [ ${request.method.value}: ${request.uri.toString()} ]"
+                      )
+                    }
+                    if (res.status.isSuccess()) Future(res)
+                    else Future.failed(HttpErrorRaw(res, None))
+                  }
             }
-            .flatMap { res =>
-              if (res.status.isSuccess()) Future(res)(as.dispatcher)
-              else Future.failed(HttpErrorRaw(res, None))
-            }(as.dispatcher)
+        }
       }
     )
   }

--- a/refuel-http/src/main/scala/refuel/http/io/HttpRunner.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/HttpRunner.scala
@@ -148,7 +148,7 @@ object HttpRunner {
 
 }
 
-sealed class HttpRunner[T](request: HttpRequest, task: HttpResultExecution[T]) extends JsonTransform with HttpTask[T] {
+class HttpRunner[T](request: HttpRequest, task: HttpResultExecution[T]) extends JsonTransform with HttpTask[T] {
   me =>
 
   import akka.http.scaladsl.model.MediaTypes._

--- a/refuel-http/src/main/scala/refuel/http/io/setting/HttpClientLogEnabled.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/setting/HttpClientLogEnabled.scala
@@ -1,0 +1,14 @@
+package refuel.http.io.setting
+
+import com.typesafe.config.ConfigFactory
+
+case class HttpClientLogEnabled(enabled: Boolean) extends AnyVal
+
+object HttpClientLogEnabled {
+  lazy final val Default = {
+    val conf = ConfigFactory.load()
+    HttpClientLogEnabled(
+      if (conf.hasPath("http-client.logging.enabled")) conf.getBoolean("http-client.logging.enabled") else false
+    )
+  }
+}

--- a/refuel-http/src/test/resources/logback.xml
+++ b/refuel-http/src/test/resources/logback.xml
@@ -1,0 +1,20 @@
+<configuration>
+    <!-- This is a development logging configuration that logs to standard out, for an example of a production
+        logging config, see the Akka docs: https://doc.akka.io/docs/akka/2.6/typed/logging.html#logback -->
+    <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>[%date{ISO8601}] [%level] [%logger] [%thread] [%X{akkaSource}] - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
+        <queueSize>1024</queueSize>
+        <neverBlock>true</neverBlock>
+        <appender-ref ref="STDOUT" />
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="ASYNC"/>
+    </root>
+
+</configuration>

--- a/refuel-http/src/test/resources/reference.conf
+++ b/refuel-http/src/test/resources/reference.conf
@@ -11,3 +11,5 @@ akka.http {
     max-connections = 100
   }
 }
+
+http-client.logging.enabled = true

--- a/refuel-json/README.md
+++ b/refuel-json/README.md
@@ -1,7 +1,7 @@
 # refuel-json
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-json" % "1.3.14"
+libraryDependencies += "com.phylage" %% "refuel-json" % "1.3.15"
 ```
 
 refuel-json automatically generates codec and supports JSON mutual conversion fast and easy.

--- a/refuel-json/src/main/scala/refuel/json/entry/JsArray.scala
+++ b/refuel-json/src/main/scala/refuel/json/entry/JsArray.scala
@@ -16,9 +16,7 @@ case class JsArray private (bf: Seq[JsonVal]) extends JsVariable {
   }
 
   override def named(key: String): JsonVal = {
-    val r = bf.map(_.named(key)).foldLeft(JsArray(None))(_ ++ _)
-    println(r)
-    r
+    bf.map(_.named(key)).foldLeft(JsArray(None))(_ ++ _)
   }
 
   def ++(js: JsonVal): JsArray = {

--- a/refuel-json/src/main/scala/refuel/json/entry/JsArray.scala
+++ b/refuel-json/src/main/scala/refuel/json/entry/JsArray.scala
@@ -1,5 +1,6 @@
 package refuel.json.entry
 
+import refuel.internal.json.codec.builder.JsonKeyRef
 import refuel.json.JsonVal
 
 case class JsArray private (bf: Seq[JsonVal]) extends JsVariable {
@@ -14,17 +15,22 @@ case class JsArray private (bf: Seq[JsonVal]) extends JsVariable {
     sb.append(']')
   }
 
-  def ++(js: JsonVal): JsonVal = {
+  override def named(key: String): JsonVal = {
+    val r = bf.map(_.named(key)).foldLeft(JsArray(None))(_ ++ _)
+    println(r)
+    r
+  }
+
+  def ++(js: JsonVal): JsArray = {
     if (js == null) this
     else {
       js match {
         case JsArray(x) => JsArray(bf ++ x)
+        case JsNull     => this
         case _          => JsArray(bf :+ js)
       }
     }
   }
-
-  override def named(key: String): JsonVal = copy(bf.map(_.named(key)))
 
   override def writeToBufferString(buffer: StringBuffer): Unit = {
     var unempty = false

--- a/refuel-json/src/main/scala/refuel/json/entry/JsEntry.scala
+++ b/refuel-json/src/main/scala/refuel/json/entry/JsEntry.scala
@@ -1,5 +1,6 @@
 package refuel.json.entry
 
+import refuel.internal.json.codec.builder.JsonKeyRef
 import refuel.json.JsonVal
 import refuel.json.error.UnsupportedOperation
 
@@ -50,10 +51,11 @@ case class JsEntry(key: JsString, value: JsonVal) extends JsonVal {
     * @param _key Target json key name
     * @return
     */
-  override def named(_key: String): JsonVal =
+  override def named(_key: String): JsonVal = {
     if (key.pure == _key) {
       value
     } else JsNull
+  }
 
   override def writeToBufferString(buffer: StringBuffer): Unit = JsObject.fromEntry(this).writeToBufferString(buffer)
 }

--- a/refuel-json/src/main/scala/refuel/json/logging/JsonLoggingStrategy.scala
+++ b/refuel-json/src/main/scala/refuel/json/logging/JsonLoggingStrategy.scala
@@ -4,7 +4,6 @@ import com.typesafe.scalalogging.LazyLogging
 import refuel.json.JsonVal
 
 trait JsonLoggingStrategy extends LazyLogging {
-
   def jsonReadLogging(v: => JsonVal)(implicit logEnabled: JsonConvertLogEnabled): JsonVal = {
     val res = v
     if (logEnabled.enabled) {

--- a/refuel-json/src/test/scala/refuel/json/JsonTransformTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/JsonTransformTest.scala
@@ -1,8 +1,8 @@
 package refuel.json
 
-import org.scalatest.wordspec.AsyncWordSpec
 import org.scalatest.diagrams.Diagrams
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 import refuel.json.entry.JsEmpty
 import refuel.json.error.IllegalJsonFormat
 import refuel.json.model.TestJson.JString
@@ -79,11 +79,39 @@ class JsonTransformTest extends AsyncWordSpec with Matchers with Diagrams with J
     "fail case - Not found key name" in {
       s"""{"value":"3"}""".as(ConstCodec.from("hoge")(JString.apply)(JString.unapply)) match {
         case Left(e) =>
-          e.printStackTrace()
           e.getMessage shouldBe """Internal structure analysis by class refuel.json.codecs.JoinableCodec$T1 raised an exception."""
           e.getCause.getMessage shouldBe s"""Cannot deserialize null into a String"""
         case Right(r) => fail(r.toString)
       }
+    }
+    "Nested array tree" in {
+      val json = s"""
+         |{
+         |  "blocks": [
+         |    {
+         |      "type": "rich_text",
+         |      "block_id": "vMWQ",
+         |      "elements": [
+         |        {
+         |          "type": "rich_text_section",
+         |          "elements": [
+         |            {
+         |              "type": "user",
+         |              "user_id": "U01BBCSP6NP"
+         |            },
+         |            {
+         |              "type": "text",
+         |              "text": "hey"
+         |            }
+         |          ]
+         |        }
+         |      ]
+         |    }
+         |  ]
+         |}
+         |""".stripMargin.jsonTree
+      json.named("blocks").named("elements").named("elements").named("text") shouldBe Json.arr(Json.str("hey"))
+      json.named("blocks" @@ "elements" @@ "elements" @@ "text") shouldBe Json.arr(Json.str("hey"))
     }
   }
 }

--- a/refuel-macro/src/main/scala/refuel/json/JsonVal.scala
+++ b/refuel-macro/src/main/scala/refuel/json/JsonVal.scala
@@ -1,16 +1,9 @@
 package refuel.json
 
+import refuel.internal.json.codec.builder.JsonKeyRef
 import refuel.json.codecs.{Read, Write}
 
 trait JsonVal extends Serializable {
-
-  private[refuel] def pure: String = toString
-
-  override def toString: String = {
-    val buf = new StringBuffer()
-    writeToBufferString(buf)
-    buf.toString
-  }
 
   def writeToBufferString(buffer: StringBuffer): Unit
 
@@ -19,7 +12,8 @@ trait JsonVal extends Serializable {
     *
     * @return
     */
-  def isEmpty: Boolean     = false
+  def isEmpty: Boolean = false
+
   def isNonEmptry: Boolean = true
 
   /**
@@ -61,7 +55,7 @@ trait JsonVal extends Serializable {
     * @param key Target json key name
     * @return
     */
-  def named(key: String): JsonVal
+  def named(key: JsonKeyRef): JsonVal = key.dig(this)
 
   /**
     * Squash the Json buffer under construction.
@@ -78,6 +72,16 @@ trait JsonVal extends Serializable {
     * @return
     */
   def isSquashable: Boolean = false
+
+  private[refuel] def named(key: String): JsonVal
+
+  private[refuel] def pure: String = toString
+
+  override def toString: String = {
+    val buf = new StringBuffer()
+    writeToBufferString(buf)
+    buf.toString
+  }
 }
 
 object JsonVal {

--- a/refuel-util/README.md
+++ b/refuel-util/README.md
@@ -1,7 +1,7 @@
 ## refuel-util
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-util" % "1.3.14"
+libraryDependencies += "com.phylage" %% "refuel-util" % "1.3.15"
 ```
 
 ## Usage

--- a/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
+++ b/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
@@ -8,7 +8,7 @@ import refuel.domination.InjectionPriority.Finally
 import refuel.injector.{AutoInject, Injector}
 
 @deprecated("Instead, use dependency injection")
-object ScalaTime extends ScalaTime(RuntimeTZ)
+object ScalaTime extends ScalaTimeBase(RuntimeTZ)
 
 /** Use DI as a starting point.
   * ```
@@ -22,7 +22,9 @@ object ScalaTime extends ScalaTime(RuntimeTZ)
   * I would override it as needed and refer to it by mixing in the AutoInject.
   */
 @Inject(Finally)
-class ScalaTime(TZ: RuntimeTZ) extends Injector with AutoInject {
+class ScalaTime(TZ: RuntimeTZ) extends ScalaTimeBase(TZ) with AutoInject
+
+abstract class ScalaTimeBase(TZ: RuntimeTZ) extends Injector {
 
   /**
     * Get a current time.

--- a/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
+++ b/refuel-util/src/main/scala/refuel/lang/ScalaTime.scala
@@ -8,7 +8,6 @@ import refuel.domination.InjectionPriority.Finally
 import refuel.injector.{AutoInject, Injector}
 
 @deprecated("Instead, use dependency injection")
-@Inject(Finally)
 object ScalaTime extends ScalaTime(RuntimeTZ)
 
 /** Use DI as a starting point.

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.3.14"
+version in ThisBuild := "1.3.15"


### PR DESCRIPTION
## Flatting of Json sequence extraction

Fixed array nesting when digging Json arrays by digging or named, so they are now flattened.

## Add HTTP request logging.

You can set `http-client.logging.enabled` to output latency and destination of a request by setting `http-client.logging.enabled` at the Http request.