### PR TITLE
Fix json AST builder bug.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,15 +5,20 @@ releaseCrossBuild in Scope.Global := true
 crossScalaVersions in Scope.Global := Seq("2.12.12", "2.13.4")
 scalaVersion in Scope.Global := "2.13.4"
 
-lazy val akkaVersion     = "2.6.10"
-lazy val akkaHttpVersion = "10.2.2"
-lazy val pac4jVersion    = "4.1.0"
+lazy val akkaVersion           = "2.6.11"
+lazy val akkaHttpVersion       = "10.2.3"
+lazy val pac4jVersion          = "4.1.0"
+lazy val pureconfigVersion     = "0.14.0"
+lazy val scalacheckVersion     = "1.15.2"
+lazy val scalamockVersion      = "5.1.0"
+lazy val scalaLoggingVersion   = "3.9.2"
+lazy val typesafeConfigVersion = "1.4.1"
 
 libraryDependencies in Scope.Global ++= {
-  Seq("org.scalatest" %% "scalatest" % "3.1.0" % Test)
+  Seq("org.scalatest" %% "scalatest" % "3.2.3" % Test)
 }
 libraryDependencies in Scope.Global ++= scl213(
-  Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "0.2.0")
+  Seq("org.scala-lang.modules" %% "scala-parallel-collections" % "1.0.0")
 ).value
 
 lazy val asemble = Seq(
@@ -81,7 +86,7 @@ lazy val `macro` = (project in file("refuel-macro"))
     libraryDependencies ++= {
       Seq(
         "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-        "com.typesafe"   % "config"        % "1.3.4"
+        "com.typesafe"   % "config"        % typesafeConfigVersion
       )
     },
     scalacOptions += "-language:experimental.macros"
@@ -95,7 +100,7 @@ lazy val container = (project in file("refuel-container"))
     parallelExecution in Test := false,
     libraryDependencies ++= Seq(
         "org.scala-lang"             % "scala-reflect"  % scalaVersion.value,
-        "com.typesafe.scala-logging" %% "scala-logging" % "3.9.2"
+        "com.typesafe.scala-logging" %% "scala-logging" % scalaLoggingVersion
       ),
     scalacOptions in Global ++= Seq(
 //            "-Ydebug",
@@ -169,8 +174,8 @@ lazy val auth = (project in file("refuel-auth-provider"))
         "com.typesafe.akka"     %% "akka-stream"         % akkaVersion,
         "com.typesafe.akka"     %% "akka-http"           % akkaHttpVersion,
         "org.pac4j"             % "pac4j-saml"           % pac4jVersion,
-        "com.github.pureconfig" %% "pureconfig"          % "0.12.3",
-        "org.scalacheck"        %% "scalacheck"          % "1.14.3" % Test,
+        "com.github.pureconfig" %% "pureconfig"          % pureconfigVersion,
+        "org.scalacheck"        %% "scalacheck"          % scalacheckVersion % Test,
         "com.typesafe.akka"     %% "akka-http-testkit"   % akkaHttpVersion % Test,
         "com.typesafe.akka"     %% "akka-stream-testkit" % akkaVersion % Test
       )
@@ -184,9 +189,9 @@ lazy val oauth = (project in file("refuel-oauth-provider"))
     libraryDependencies ++= Seq(
         "com.typesafe.akka"     %% "akka-stream"         % akkaVersion,
         "com.typesafe.akka"     %% "akka-http"           % akkaHttpVersion,
-        "com.github.pureconfig" %% "pureconfig"          % "0.12.3",
-        "org.scalacheck"        %% "scalacheck"          % "1.14.3" % Test,
-        "org.scalamock"         %% "scalamock"           % "4.4.0" % Test,
+        "com.github.pureconfig" %% "pureconfig"          % pureconfigVersion,
+        "org.scalacheck"        %% "scalacheck"          % scalacheckVersion % Test,
+        "org.scalamock"         %% "scalamock"           % scalamockVersion % Test,
         "com.typesafe.akka"     %% "akka-http-testkit"   % akkaHttpVersion % Test,
         "com.typesafe.akka"     %% "akka-stream-testkit" % akkaVersion % Test
       )

--- a/refuel-auth-provider/README.md
+++ b/refuel-auth-provider/README.md
@@ -1,7 +1,7 @@
 # refuel-saml-provider
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-auth-provider" % "1.4.6"
+libraryDependencies += "com.phylage" %% "refuel-auth-provider" % "1.4.7"
 ```
 
 Provides SAML 2.0 service provider support for Akka http. The refuel framework will be worked on to support Scala 3.

--- a/refuel-auth-provider/src/test/scala/refuel/store/InMemorySessionStorageTest.scala
+++ b/refuel-auth-provider/src/test/scala/refuel/store/InMemorySessionStorageTest.scala
@@ -1,17 +1,18 @@
 package refuel.store
 
 import akka.http.scaladsl.testkit.ScalatestRouteTest
-import org.scalatest.{Matchers, WordSpecLike}
 import refuel.injector.Injector
 import refuel.lang.ScalaTime
 import refuel.AkkaHttpWebContext.SessionId
 import InMemorySessionStorage.{DataRecord, ExpiryRecord}
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 import refuel.saml.SAMLAuthConfig
 
 import scala.concurrent.duration._
 import scala.language.reflectiveCalls
 
-class InMemorySessionStorageTest extends WordSpecLike with Matchers with ScalatestRouteTest with Injector {
+class InMemorySessionStorageTest extends AsyncWordSpec with Matchers with ScalatestRouteTest with Injector {
 
   implicit final def toSessionId(v: String): SessionId = SessionId(v)
   def mockedTimeStorage() =
@@ -24,8 +25,8 @@ class InMemorySessionStorageTest extends WordSpecLike with Matchers with Scalate
     "add a data and expiry record" in {
       val storage = mockedTimeStorage()
       storage.createOrReuseSession(SessionId("session")) shouldBe true
-      storage.expiryQueue shouldBe Set(ExpiryRecord(1, "session"))
-      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(1L, "session"))
+      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1L, Map.empty))
     }
 
     "return false when the session already existed" in {
@@ -37,12 +38,12 @@ class InMemorySessionStorageTest extends WordSpecLike with Matchers with Scalate
     "expire earlier sessions" in {
       val storage = mockedTimeStorage()
       storage.createOrReuseSession("session")
-      storage.expiryQueue shouldBe Set(ExpiryRecord(1, "session"))
-      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(1L, "session"))
+      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1L, Map.empty))
       storage.time = 2
       storage.createOrReuseSession("session2")
-      storage.expiryQueue shouldBe Set(ExpiryRecord(2, "session2"))
-      storage.sessionData shouldBe Map(SessionId("session2") -> DataRecord(2, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(2L, "session2"))
+      storage.sessionData shouldBe Map(SessionId("session2") -> DataRecord(2L, Map.empty))
     }
   }
 
@@ -61,8 +62,8 @@ class InMemorySessionStorageTest extends WordSpecLike with Matchers with Scalate
     "expire earlier sessions" in {
       val storage = mockedTimeStorage()
       storage.createOrReuseSession("session")
-      storage.expiryQueue shouldBe Set(ExpiryRecord(1, "session"))
-      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(1L, "session"))
+      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1L, Map.empty))
       storage.time = 2
       storage.sessionExists("session") shouldBe false
       storage.expiryQueue shouldBe Set()
@@ -92,8 +93,8 @@ class InMemorySessionStorageTest extends WordSpecLike with Matchers with Scalate
     "expire earlier sessions" in {
       val storage = mockedTimeStorage()
       storage.createOrReuseSession("session")
-      storage.expiryQueue shouldBe Set(ExpiryRecord(1, "session"))
-      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(1L, "session"))
+      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1L, Map.empty))
       storage.time = 2
       storage.getSessionValue("session", "mykey") shouldBe None
       storage.expiryQueue shouldBe Set()
@@ -145,8 +146,8 @@ class InMemorySessionStorageTest extends WordSpecLike with Matchers with Scalate
     "expire earlier sessions" in {
       val storage = mockedTimeStorage()
       storage.createOrReuseSession("session")
-      storage.expiryQueue shouldBe Set(ExpiryRecord(1, "session"))
-      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(1L, "session"))
+      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1L, Map.empty))
       storage.time = 2
       storage.setSessionValue("session", "mykey", "yoo") shouldBe true
       storage.expiryQueue shouldBe Set()
@@ -189,8 +190,8 @@ class InMemorySessionStorageTest extends WordSpecLike with Matchers with Scalate
       val storage = mockedTimeStorage
       storage.createOrReuseSession("session")
       storage.renewSession("session") shouldBe true
-      storage.expiryQueue shouldBe Set(ExpiryRecord(1, "session"))
-      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1, Map.empty))
+      storage.expiryQueue shouldBe Set(ExpiryRecord(1L, "session"))
+      storage.sessionData shouldBe Map(SessionId("session") -> DataRecord(1L, Map.empty))
     }
 
     "expire earlier sessions" in {

--- a/refuel-cipher/README.md
+++ b/refuel-cipher/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-cipher" % "1.4.6"
+libraryDependencies += "com.phylage" %% "refuel-cipher" % "1.4.7"
 ````
 
 ## Usage

--- a/refuel-container/README.md
+++ b/refuel-container/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-container" % "1.4.6"
+libraryDependencies += "com.phylage" %% "refuel-container" % "1.4.7"
 ````
 
 ## Features

--- a/refuel-container/src/main/scala/refuel/container/DefaultContainer.scala
+++ b/refuel-container/src/main/scala/refuel/container/DefaultContainer.scala
@@ -129,7 +129,6 @@ private[refuel] class DefaultContainer private (val lights: Vector[Container] = 
 
   private[refuel] override def shading: @@[Container, Types.Localized] = {
     DefaultContainer(
-      buffer = _buffer.snapshot(),
       lights = this.lights.:+(this)
     )
   }

--- a/refuel-http/README.md
+++ b/refuel-http/README.md
@@ -4,7 +4,7 @@
 
 ```
 libraryDependencies ++= Seq(
-  "com.phylage"       %% "refuel-http" % "1.4.6",
+  "com.phylage"       %% "refuel-http" % "1.4.7",
   "com.typesafe.akka" %% "akka-stream" % "2.6.4",
   "com.typesafe.akka" %% "akka-http"   % "10.1.11"
 )

--- a/refuel-json/README.md
+++ b/refuel-json/README.md
@@ -1,7 +1,7 @@
 # refuel-json
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-json" % "1.4.6"
+libraryDependencies += "com.phylage" %% "refuel-json" % "1.4.7"
 ```
 
 refuel-json automatically generates codec and supports JSON mutual conversion fast and easy.

--- a/refuel-json/src/main/scala/refuel/json/JsonTransform.scala
+++ b/refuel-json/src/main/scala/refuel/json/JsonTransform.scala
@@ -1,6 +1,6 @@
 package refuel.json
 
-import refuel.json.codecs.Write
+import refuel.json.codecs.{Read, Write}
 import refuel.json.logging.{JsonConvertLogEnabled, JsonLoggingStrategy}
 import refuel.json.tokenize.decoded.DecodedJsonRaw
 import refuel.json.tokenize.strategy.JsonEntry
@@ -63,4 +63,12 @@ trait JsonTransform extends JsonLoggingStrategy {
     def toJString[X >: T](implicit ct: Write[X]): String = encodedStr[X]
   }
 
+}
+
+object JsonTransform extends JsonTransform {
+  def encodedStr[T: Write](v: T): String = v.encodedStr
+
+  def as[T: Read](v: String): Either[Throwable, T] = v.as
+
+  def jsonTree(v: String): JsonVal = v.jsonTree
 }

--- a/refuel-json/src/main/scala/refuel/json/entry/JsString.scala
+++ b/refuel-json/src/main/scala/refuel/json/entry/JsString.scala
@@ -69,6 +69,6 @@ case class JsString private (literal: String) extends JsVariable {
 }
 
 object JsString {
-  def apply(literal: String): JsString     = new JsString(literal.trim)
-  def apply(literal: JsonKeyRef): JsString = new JsString(literal.toString.trim)
+  def apply(literal: String): JsString     = new JsString(literal)
+  def apply(literal: JsonKeyRef): JsString = new JsString(literal.toString)
 }

--- a/refuel-json/src/main/scala/refuel/json/tokenize/decoded/DecodedJsonTokenizer.scala
+++ b/refuel-json/src/main/scala/refuel/json/tokenize/decoded/DecodedJsonTokenizer.scala
@@ -29,6 +29,7 @@ class DecodedJsonTokenizer(rs: Array[Char]) extends JsonTokenizer(rs) {
     } else {
       incl()
       if (pos <= length) {
+        if (chbuff.length <= len) glowArray(len)
         chbuff(len) = fromEscaping(rs(pos))
         incl()
         len + 1

--- a/refuel-json/src/test/scala/refuel/json/JsonTransformTest.scala
+++ b/refuel-json/src/test/scala/refuel/json/JsonTransformTest.scala
@@ -17,6 +17,9 @@ class JsonTransformTest extends AsyncWordSpec with Matchers with Diagrams with J
     }
 
     "Unicode type" in {
+      s"""{"title":"${(1 to 1 << 8).map(_ => "\\n").mkString}"}""".jsonTree shouldBe Json.obj(
+        "title" -> (1 to 1 << 8).map(_ => "\n").mkString
+      )
       s"""{"value":"test\uD83C\uDF0Ftest\uD83C\uDF0Ftest"}""".jsonTree shouldBe Json.obj(
         "value" -> s"""test🌏test🌏test"""
       )
@@ -95,7 +98,7 @@ class JsonTransformTest extends AsyncWordSpec with Matchers with Diagrams with J
     "fail case - Syntax error" in {
       intercept[IllegalJsonFormat] {
         s"""{"value: "aaa"}""".jsonTree
-      }.getMessage shouldBe s"""Unspecified json value of key: #"value:"#"""
+      }.getMessage shouldBe s"""Unspecified json value of key: #"value: "#"""
     }
     "fail case - EOF position 2" in {
       intercept[IllegalJsonFormat] {

--- a/refuel-oauth-provider/README.md
+++ b/refuel-oauth-provider/README.md
@@ -1,7 +1,7 @@
 ## refuel-akka-oauth-provider
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-oauth-provider" % "1.4.6"
+libraryDependencies += "com.phylage" %% "refuel-oauth-provider" % "1.4.7"
 ```
 
 It provides an authorization process directive that follows the standard features of OAuth 2.0 / 2.1.

--- a/refuel-util/README.md
+++ b/refuel-util/README.md
@@ -1,7 +1,7 @@
 ## refuel-util
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-util" % "1.4.6"
+libraryDependencies += "com.phylage" %% "refuel-util" % "1.4.7"
 ```
 
 ## Usage

--- a/test-across-module/call_interfaces/src/test/scala/refuel/test/ModuleAcrossInjectionTest.scala
+++ b/test-across-module/call_interfaces/src/test/scala/refuel/test/ModuleAcrossInjectionTest.scala
@@ -1,9 +1,11 @@
 package refuel.test
 
-import org.scalatest.{AsyncWordSpec, DiagrammedAssertions, Matchers}
+import org.scalatest.diagrams.Diagrams
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AsyncWordSpec
 import refuel.test.Executor.{InjectionExecution, PureExecution}
 
-class ModuleAcrossInjectionTest extends AsyncWordSpec with Matchers with DiagrammedAssertions {
+class ModuleAcrossInjectionTest extends AsyncWordSpec with Matchers with Diagrams {
   "Module across injection test" should {
     "pure call" in {
       PureExecution.exec shouldBe ConfImpl.value

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.6"
+version in ThisBuild := "1.4.7"


### PR DESCRIPTION
## Update submodules

It has been updated to the latest version available at this time. (This was only verified on unit tests, so unexpected incompatibilities may occur.


## Bug fix build AST

Fixed a bug that caused an out of bound error when converting a JSON type string to AST, if the shifted bit number position of 1 << 8 or more was white space.

## Lighten container shading.

Reduced dependency buffers for replicated container instances, since shading is supposed to be called a lot during test.