### PR TITLE
Fix container lifecycle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,43 +31,13 @@ jobs:
           name: Cross version compile
           command: |
             sbt -mem 3000 sbtVersion +clean +compile
-          no_output_timeout: 5m
+          no_output_timeout: 30m
 
       - run:
           name: Cross version test1
           command: |
-            sbt -mem 3000 +macro/test
-          no_output_timeout: 5m
-
-      - run:
-          name: Cross version test2
-          command: |
-            sbt -mem 3000 +container/test
-          no_output_timeout: 5m
-
-      - run:
-          name: Cross version test3
-          command: |
-            sbt -mem 3000 +util/test
-          no_output_timeout: 5m
-
-      - run:
-          name: Cross version test4
-          command: |
-            sbt -mem 3000 +json/test
-          no_output_timeout: 5m
-
-      - run:
-          name: Cross version test5
-          command: |
-            sbt -mem 3000 +auth/test
-          no_output_timeout: 5m
-
-      - run:
-          name: Cross version test6
-          command: |
-            sbt -mem 3000 +cipher/test
-          no_output_timeout: 5m
+            sbt -mem 3000 +test
+          no_output_timeout: 30m
 
       - save_cache:
           paths:

--- a/refuel-auth-provider/README.md
+++ b/refuel-auth-provider/README.md
@@ -1,7 +1,7 @@
 # refuel-saml-provider
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-auth-provider" % "1.4.10"
+libraryDependencies += "com.phylage" %% "refuel-auth-provider" % "1.4.11"
 ```
 
 Provides SAML 2.0 service provider support for Akka http. The refuel framework will be worked on to support Scala 3.

--- a/refuel-cipher/README.md
+++ b/refuel-cipher/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-cipher" % "1.4.10"
+libraryDependencies += "com.phylage" %% "refuel-cipher" % "1.4.11"
 ````
 
 ## Usage

--- a/refuel-cipher/src/test/scala/refuel/cipher/aes/AESCipherTest.scala
+++ b/refuel-cipher/src/test/scala/refuel/cipher/aes/AESCipherTest.scala
@@ -13,7 +13,7 @@ class AESCipherTest extends AsyncWordSpec with Matchers with Diagrams with Injec
 
   "(RAW) String => (ENC) String => (RAW) String" should {
     "Encrypt by GCM" in {
-      shade { implicit c =>
+      closed { implicit c =>
         val secret = AESKeyFactory.withGCMParam()
         new AES_GCM_NoPadding().index[CipherAlg[AES]]()
         val raw    = (1 to 1012).map(_ => "x").mkString
@@ -25,7 +25,7 @@ class AESCipherTest extends AsyncWordSpec with Matchers with Diagrams with Injec
       }
     }
     "Encrypt by CBC" in {
-      shade { implicit c =>
+      closed { implicit c =>
         val secret = AESKeyFactory.withIvParam()
         val raw    = (1 to 16).map(_ => "x").mkString
         val cipher = inject[CryptographyConverter[AES]]
@@ -36,7 +36,7 @@ class AESCipherTest extends AsyncWordSpec with Matchers with Diagrams with Injec
       }
     }
     "Failure not 16 bytes encryption by CBC" in {
-      shade { implicit c =>
+      closed { implicit c =>
         intercept[IllegalBlockSizeException] {
           val secret = AESKeyFactory.withIvParam()
           val raw    = (1 to 17).map(_ => "x").mkString

--- a/refuel-container/README.md
+++ b/refuel-container/README.md
@@ -1,7 +1,7 @@
 # refuel-container
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-container" % "1.4.10"
+libraryDependencies += "com.phylage" %% "refuel-container" % "1.4.11"
 ````
 
 ## Features

--- a/refuel-container/src/main/scala/refuel/container/indexer/CanBeClosedIndexer.scala
+++ b/refuel-container/src/main/scala/refuel/container/indexer/CanBeClosedIndexer.scala
@@ -40,8 +40,7 @@ class CanBeClosedIndexer[T](scope: IndexedSymbol[T], cnt: Vector[Container]) ext
       scope.value,
       scope.priority,
       scope.tag,
-      Vector(x),
-      scope.c
+      Vector(x)
     ),
     cnt
   )
@@ -59,8 +58,7 @@ class CanBeClosedIndexer[T](scope: IndexedSymbol[T], cnt: Vector[Container]) ext
       scope.value,
       scope.priority,
       scope.tag,
-      Vector(classTag[X].runtimeClass),
-      scope.c
+      Vector(classTag[X].runtimeClass)
     ),
     cnt
   )

--- a/refuel-container/src/main/scala/refuel/injector/HiddenContainerShade.scala
+++ b/refuel-container/src/main/scala/refuel/injector/HiddenContainerShade.scala
@@ -5,5 +5,5 @@ import refuel.Types.LocalizedContainer
 private[refuel] class HiddenContainerShade[T](val fx: LocalizedContainer => T)(c: LocalizedContainer)
     extends MetaMediation[LocalizedContainer] {
   it =>
-  implicit var _cntMutation: LocalizedContainer = c
+  implicit var _cntRef: LocalizedContainer = c
 }

--- a/refuel-container/src/main/scala/refuel/injector/Injector.scala
+++ b/refuel-container/src/main/scala/refuel/injector/Injector.scala
@@ -2,16 +2,16 @@ package refuel.injector
 
 import refuel.container.{Container, ContainerLifeCycle}
 import refuel.domination.InjectionPriority
-import refuel.domination.InjectionPriority.Default
+import refuel.domination.InjectionPriority.{Default, Overwrite}
 
 import scala.reflect.runtime.universe._
 
 trait Injector extends MetaMediation[Container] {
-  implicit var _cntMutation: Container = implicitly[ContainerLifeCycle].ctn
+  implicit var _cntRef: Container = implicitly[ContainerLifeCycle].ctn
 
   protected final implicit class _Registrable[T](t: T) {
-    def index[X >: T: WeakTypeTag](p: InjectionPriority = Default)(implicit c: Container): X = {
-      c.createIndexer[X](t, p).indexing().value
+    def index[X >: T: WeakTypeTag](p: InjectionPriority = Overwrite)(implicit c: Container): X = {
+      c.createIndexer[X](t, p, Vector.empty).indexing().value
     }
   }
 }

--- a/refuel-container/src/main/scala/refuel/injector/MetaMediation.scala
+++ b/refuel-container/src/main/scala/refuel/injector/MetaMediation.scala
@@ -48,7 +48,7 @@ private[refuel] trait MetaMediation[C <: Container] extends CanBeContainer[C] {
     *   class C(b: B)
     *   class D(c: C)
     *   shade { implicit c =>
-    *     new BStub().index()
+    *     new BStub().index[B]()
     *     inject[D].run // Use BStub in C in D
     *   }
     *   inject[D].run // Use A in B in C in D
@@ -59,7 +59,10 @@ private[refuel] trait MetaMediation[C <: Container] extends CanBeContainer[C] {
     * @return
     */
   def shade[T](ctx: LocalizedContainer => T): T =
-    new HiddenContainerShade(ctx)(_cntMutation.shading)
+    new HiddenContainerShade(ctx)(_cntRef.shading)
+
+  def closed[T](ctx: LocalizedContainer => T): T =
+    new HiddenContainerShade(ctx)(DefaultContainer())
 
   /**
     * Gets an indexer for registering new dependencies.

--- a/refuel-container/src/main/scala/refuel/injector/package.scala
+++ b/refuel-container/src/main/scala/refuel/injector/package.scala
@@ -11,5 +11,5 @@ package object injector {
 
   import scala.language.implicitConversions
 
-  implicit def _containerInheritance[T](x: HiddenContainerShade[T]): T = x.fx(x._cntMutation)
+  implicit def _containerInheritance[T](x: HiddenContainerShade[T]): T = x.fx(x._cntRef)
 }

--- a/refuel-container/src/main/scala/refuel/injector/scope/AcceptedFromInstanceSymbol.scala
+++ b/refuel-container/src/main/scala/refuel/injector/scope/AcceptedFromInstanceSymbol.scala
@@ -1,6 +1,5 @@
 package refuel.injector.scope
 
-import refuel.container.Container
 import refuel.domination.InjectionPriority
 
 import scala.reflect.runtime.universe._
@@ -19,8 +18,7 @@ private[refuel] case class AcceptedFromInstanceSymbol[T](
     value: T,
     priority: InjectionPriority,
     x: Type,
-    acceptedFrom: Vector[Any],
-    c: Container
+    acceptedFrom: Vector[Any]
 ) extends IndexedTagSymbol[T](x) {
 
   /**

--- a/refuel-container/src/main/scala/refuel/injector/scope/AcceptedFromTypeSymbol.scala
+++ b/refuel-container/src/main/scala/refuel/injector/scope/AcceptedFromTypeSymbol.scala
@@ -1,6 +1,5 @@
 package refuel.injector.scope
 
-import refuel.container.Container
 import refuel.domination.InjectionPriority
 
 import scala.reflect.runtime.universe._
@@ -19,8 +18,7 @@ private[refuel] case class AcceptedFromTypeSymbol[T](
     value: T,
     priority: InjectionPriority,
     x: Type,
-    acceptedFrom: Vector[Class[_]],
-    c: Container
+    acceptedFrom: Vector[Class[_]]
 ) extends IndexedTagSymbol[T](x) {
 
   /**

--- a/refuel-container/src/main/scala/refuel/injector/scope/CanBeRestrictedSymbol.scala
+++ b/refuel-container/src/main/scala/refuel/injector/scope/CanBeRestrictedSymbol.scala
@@ -1,6 +1,5 @@
 package refuel.injector.scope
 
-import refuel.container.Container
 import refuel.domination.InjectionPriority
 
 import scala.reflect.runtime.universe._
@@ -9,8 +8,7 @@ private[refuel] case class CanBeRestrictedSymbol[T](
     key: scala.Symbol,
     value: T,
     priority: InjectionPriority,
-    x: Type,
-    c: Container
+    x: Type
 ) extends IndexedTagSymbol[T](x) {
 
   /**

--- a/refuel-http/README.md
+++ b/refuel-http/README.md
@@ -4,7 +4,7 @@
 
 ```
 libraryDependencies ++= Seq(
-  "com.phylage"       %% "refuel-http" % "1.4.10",
+  "com.phylage"       %% "refuel-http" % "1.4.11",
   "com.typesafe.akka" %% "akka-stream" % "2.6.4",
   "com.typesafe.akka" %% "akka-http"   % "10.1.11"
 )

--- a/refuel-http/src/main/scala/refuel/http/io/Http.scala
+++ b/refuel-http/src/main/scala/refuel/http/io/Http.scala
@@ -89,7 +89,7 @@ class Http(val setting: Lazy[HttpSetting]) extends Injector with JsonTransform w
                   .flatMap { res =>
                     if (logging.enabled) {
                       logger.info(
-                        s"Http request completed ${res.status.intValue()}. ${(System
+                        s"Http request completed. ${(System
                           .currentTimeMillis() - from).toFloat / 1000} sec [ ${request.method.value}: ${request.uri.toString()} ]"
                       )
                     }

--- a/refuel-json/README.md
+++ b/refuel-json/README.md
@@ -1,7 +1,7 @@
 # refuel-json
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-json" % "1.4.10"
+libraryDependencies += "com.phylage" %% "refuel-json" % "1.4.11"
 ```
 
 refuel-json automatically generates codec and supports JSON mutual conversion fast and easy.

--- a/refuel-macro/src/main/scala/refuel/container/CanBeContainer.scala
+++ b/refuel-macro/src/main/scala/refuel/container/CanBeContainer.scala
@@ -8,7 +8,7 @@ import scala.language.implicitConversions
 trait CanBeContainer[C <: Container] {
   me =>
   /* Container instance */
-  implicit var _cntMutation: C
+  implicit var _cntRef: C
 
   /**
     * This refers to itself.

--- a/refuel-macro/src/main/scala/refuel/container/Container.scala
+++ b/refuel-macro/src/main/scala/refuel/container/Container.scala
@@ -28,6 +28,14 @@ trait Container {
     * @param requestFrom Inject caller.
     * @return
     */
+  def find[T, A: TypedAcceptContext](tpe: universe.Type, requestFrom: A): Option[T]
+
+  /**
+    * May return an injectable object.
+    *
+    * @param requestFrom Inject caller.
+    * @return
+    */
   def find[T: WeakTypeTag, A: TypedAcceptContext](requestFrom: A): Option[T]
 
   /**
@@ -62,4 +70,6 @@ trait Container {
   private[refuel] def createScope[T: WeakTypeTag](x: T, priority: InjectionPriority): IndexedSymbol[T]
 
   private[refuel] def shading: Container @@ Localized
+
+  private[refuel] def fully[T: WeakTypeTag]: Iterable[T]
 }

--- a/refuel-macro/src/main/scala/refuel/injector/scope/IndexedSymbol.scala
+++ b/refuel-macro/src/main/scala/refuel/injector/scope/IndexedSymbol.scala
@@ -16,7 +16,6 @@ trait IndexedSymbol[T] {
   val value: T
   val priority: InjectionPriority
   val tag: Type
-  val c: Container
 
   /**
     * Determines if this object can be injected from any accessor.

--- a/refuel-macro/src/main/scala/refuel/internal/AutoDIExtractor.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/AutoDIExtractor.scala
@@ -30,7 +30,7 @@ object AutoDIExtractor {
     val runtimeClasspathInjectAcception = weakTypeOf[RecognizedDynamicInjection]
 
     val richSets              = new AutoInjectableSet[c.type](c)
-    val x                     = getList[C](c)
+    val x                     = getList[C, T](c)
     val compileTimeCandidates = richSets.filterModuleSymbols[T](x) ++ richSets.filterClassSymbol[T](x)
 
     val annos = weakTypeOf[T] match {
@@ -53,7 +53,7 @@ object AutoDIExtractor {
     }
   }
 
-  private[this] def getList[C <: blackbox.Context](c: C): AutoInjectableSymbols[c.type] = {
+  private[this] def getList[C <: blackbox.Context, T: c.WeakTypeTag](c: C): AutoInjectableSymbols[c.type] = {
     buffer match {
       case None =>
         new AutoDIExtractor[c.type](c).run() match {

--- a/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/LazyInitializer.scala
@@ -20,7 +20,7 @@ class LazyInitializer[C <: blackbox.Context](val c: C) {
       q"""
          (ctn: refuel.container.Container) => ${injection[T](q"ctn", ip, access)} match {
            case x: refuel.injector.Injector =>
-             x._cntMutation = ctn
+             x._cntRef = ctn
              x
            case x => x
          }

--- a/refuel-macro/src/main/scala/refuel/internal/Macro.scala
+++ b/refuel-macro/src/main/scala/refuel/internal/Macro.scala
@@ -18,7 +18,7 @@ class Macro(val c: blackbox.Context) {
           def _provide(implicit ctn: Container): T = c.Expr[T](q"""
                inject[${prType.dealias.typeArgs.head}] match {
                  case x: refuel.injector.Injector =>
-                   x._cntMutation = ctn
+                   x._cntRef = ctn
                    x
                  case x => x
                }

--- a/refuel-oauth-provider/README.md
+++ b/refuel-oauth-provider/README.md
@@ -1,7 +1,7 @@
 ## refuel-akka-oauth-provider
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-oauth-provider" % "1.4.10"
+libraryDependencies += "com.phylage" %% "refuel-oauth-provider" % "1.4.11"
 ```
 
 It provides an authorization process directive that follows the standard features of OAuth 2.0 / 2.1.

--- a/refuel-util/README.md
+++ b/refuel-util/README.md
@@ -1,7 +1,7 @@
 ## refuel-util
 
 ```
-libraryDependencies += "com.phylage" %% "refuel-util" % "1.4.10"
+libraryDependencies += "com.phylage" %% "refuel-util" % "1.4.11"
 ```
 
 ## Usage

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.4.10"
+version in ThisBuild := "1.4.11"


### PR DESCRIPTION
Fix container lifecycle

## Container#shade

The container shading is done by a scope separated only by the partial application injection in the shading, and the search from the container is done including the container from which the shading originated.
The partially applied injection is not propagated to the shading source container, so it is not referenced outside the shade scope.

```scala
inject[A] // Load new symbol
shade { implicit c =>
  new AImpl().index[A](Overwrite)
  inject[A] // used AImpl only in shade scope. 
}
inject[A] // Used already loaded
```

## Container#closed

On the other hand, if you declare a closed scope, existing containers will not be involved at all and will be expanded and searched in the cleared Container.