### PR TITLE
Fix Macro.dependentKindApplication under Scala 3.10

### DIFF
--- a/refuel-container-macro/src/main/scala-3/refuel/container/macros/Macro.scala
+++ b/refuel-container-macro/src/main/scala-3/refuel/container/macros/Macro.scala
@@ -27,7 +27,7 @@ object Macro {
       case '[Option[t]] =>
         LazyMaybeInitializer.init[t].asInstanceOf[Expr[Lazy[T]]]
       case '[Iterable[t]] =>
-        LazyAllInitializer.init[t].asInstanceOf[Expr[Lazy[T]]]
+        '{ ${LazyAllInitializer.init[t]}.asInstanceOf[Lazy[T]] }
       case _ =>
         LazyForceInitializer.init[T]
     }


### PR DESCRIPTION
Fixes issue spotted in the Scala 3 Open Community Build - under Scala 3.10 nightlies it fails with 
```scala
[error] -- Error: refuel-container/src/test/scala-3/refuel/inject/InjectorTest.scala:276:56 
[error] 276 |      val result1: Iterable[IterableDependency] = inject[List[IterableDependency]]
[error]     |                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
[error]     |Macro expansion has type refuel.container.provider.Lazy[
[error]     |  Iterable[refuel.inject.IterableTypesInjectUnionPriorities.IterableDependency]], which does not conform to the expected type refuel.container.provider.Lazy[
[error]     |  List[refuel.inject.IterableTypesInjectUnionPriorities.IterableDependency]]
[error]     |---------------------------------------------------------------------------
[error]     |Inline stack trace
[error]     |- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
[error]     |This location contains code that was inlined from Injector.scala:60
[error]  60 |  protected inline def inject[T]: refuel.container.provider.Lazy[T] = ${Macro.inject[T]}
[error]     |                                                                      ^^^^^^^^^^^^^^^^^^
[error]      ---------------------------------------------------------------------------

``` 

issue caused by improvements in macro/inlines around constant folding. 

Fix tested on Scala 3.9.0-RC5 (before changes) and 3.10.0-RC1-bin-20260812-7adc7af-NIGHTLY